### PR TITLE
Fixes Issue #19

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,7 @@ module.exports = function (options) {
 					}
 
 					self.push(new gutil.File({
-						base: path.dirname(file.path),
+						base: file.base,
 						path: gutil.replaceExtension(file.path, '.css'),
 						contents: data
 					}));


### PR DESCRIPTION
This references the initial file base path instead of redeclaring it. 

I'm really not clear as to why `base: path.dirname(file.path),` was used to declare this previously, unless it is desired to keep all the files in single tier directory after compilation. Inheriting the previous directory structure makes a lot of sense for a lot of people because it can prevent filename collisions.

If this is unacceptable, perhaps an option should be added so that the user can override the default behavior if desired.
