### PR TITLE
Fix bug related to using the same tempfile for input and output.

### DIFF
--- a/test.js
+++ b/test.js
@@ -13,12 +13,12 @@ it('should compile Sass', function (cb) {
 			assert.equal(file.relative, 'fixture.css');
 			assert.equal(
 				file.contents.toString(),
-				'.content-navigation {\n  border-color: #3bbfce; }\n\n/*# sourceMappingURL=fixture.scss.map */\n'
+				'.content-navigation {\n  border-color: #3bbfce; }\n\n/*# sourceMappingURL=fixture.css.map */\n'
 			);
 			return;
 		}
 
-		assert.equal(file.relative, 'fixture.scss.map');
+		assert.equal(file.relative, 'fixture.css.map');
 		assert.equal(JSON.parse(file.contents.toString()).version, 3);
 	});
 


### PR DESCRIPTION
I was running into an issue where the output file generated by the sass command was blank. It's hard to replicate in a minimal environment, but I was able to fix the issue by using separate files for the input/output tempfiles.

As a bonus, this also adds support for using the correct name in the sourcemap (file.css.map instead of file.scss.map).
