### PR TITLE
Ignore empty/fake warnings - fixes #31

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,8 +82,8 @@ module.exports = function (options) {
 			var errors = '';
 			cp.stderr.setEncoding('utf8');
 			cp.stderr.on('data', function (data) {
-				// ignore deprecation warnings
-				if (/DEPRECATION WARNING/.test(data)) {
+				// ignore deprecation and empty warnings
+				if (/DEPRECATION WARNING/.test(data) || '' == data.trim()) {
 					return;
 				}
 


### PR DESCRIPTION
I have the newest version of sass and gul-ruby-sass and I get this error for a valid scss file:

```
events.js:72
        throw er; // Unhandled 'error' event
              ^
Error: 





  at ChildProcess.<anonymous> (/var/webuni.cz/node_modules/gulp-ruby-sass/index.js:98:25)
  at ChildProcess.EventEmitter.emit (events.js:98:17)
  at maybeClose (child_process.js:735:16)
  at Process.ChildProcess._handle.onexit (child_process.js:802:5)
```
