### PR TITLE
Add a recursiveImports option

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,8 +11,9 @@ var chalk = require('chalk');
 
 module.exports = function (options) {
 	options = options || {};
-	var passedArgs = dargs(options, ['bundleExec']);
+	var passedArgs = dargs(options, ['bundleExec', 'recursiveImports']);
 	var bundleExec = options.bundleExec;
+	var recursiveImports = options.recursiveImports;
 
 	if (!bundleExec) {
 		try {
@@ -58,6 +59,19 @@ module.exports = function (options) {
 
 			if (bundleExec) {
 				args.unshift('bundle', 'exec');
+			}
+
+			if (recursiveImports) {
+				var files = fs.readdirSync(fileDirname)
+				files.forEach(function(file) {
+					var filePath = fileDirname + file;
+					var stat = fs.statSync(filePath);
+
+					if(stat.isDirectory()) {
+						args.push('--load-path');
+						args.push(filePath);
+					}
+				});
 			}
 
 			// if we're compiling SCSS or CSS files


### PR DESCRIPTION
This mimics the functionality compass introduced to allow imports on sub-directories without specifying the folder. At work we use Scout (http://mhs.github.io/scout-app/) for SASS development and recently we've integrated in gulp-ruby-sass into our build process. We found that there was a feature in compass that will look through all sub-directories for imports instead of specifying the folder yourself. I'd imagine other people would also be interested in this feature since it's automatically built into Scout/Compass.
