### PR TITLE
'Fix' sourcemap tests

### DIFF
--- a/test.js
+++ b/test.js
@@ -27,8 +27,7 @@ it('should compile Sass', function (cb) {
 		assert.equal(sm.version, 3);
 		assert.equal(sm.file, 'fixture.css');
 
-		// TODO: Map paths are wrong -- points to source one dir up (as makes sense)
-		// assert.equal(sm.sources[0], 'fixture.scss');
+		assert.equal(sm.sources[0], '../fixture.scss');
 	});
 
 	stream.on('end', cb);


### PR DESCRIPTION
Sourcemap paths need to be post-processed to point to the correct source files.
Still, good to have testing of a partial feature here.
