### PR TITLE
Update gulp-intermediate to 1.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ module.exports = function (options) {
 		command = 'sass';
 	}
 
-	return intermediate(compileDir, function(tempDir, cb) {
+	return intermediate({ output: compileDir, container: 'gulp-ruby-sass' }, function(tempDir, cb) {
 		if (process.argv.indexOf('--verbose') !== -1) {
 			gutil.log('gulp-ruby-sass:', 'Running command:',
 				chalk.blue(command, args.join(' ')));
@@ -74,6 +74,6 @@ module.exports = function (options) {
 
 			cb();
 		});
-	}, { customDir: 'gulp-ruby-sass' });
+	});
 };
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
   "dependencies": {
     "chalk": "^0.4.0",
     "dargs": "^0.1.0",
-    "gulp-intermediate": "^0.1.5",
+    "gulp-intermediate": "^1.0.0",
     "gulp-util": "^2.2.0",
     "win-spawn": "^2.0.0"
   },


### PR DESCRIPTION
Just some little changes to make the API nicer.

Going to add the output path option for sourcemaps in a PR branched off this one, then we can probably release.
