### PR TITLE
Make loadPath relative to gulpfile cwd

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,10 +46,13 @@ module.exports = function (options) {
 	var compileDir = '_14139e58-9ebe-4c0f-beca-73a65bb01ce9';
 	var procDir = process.cwd();
 	options = options || {};
-	options.loadPath = typeof options.loadPath === 'string' ? [options.loadPath] : options.loadPath;
-	options.loadPath = Array.isArray(options.loadPath) ? options.loadPath.map(function (loadPath) {
-		return path.join(procDir, loadPath);
-	}) : [];
+
+	if (options.loadPath) {
+		options.loadPath = [].concat(options.loadPath).map(function (loadPath) {
+			return path.join(procDir, loadPath);
+		});
+	}
+
 	options.cacheLocation = options.cacheLocation || path.join(procDir, '.sass-cache');
 	options.update = '.:' + compileDir;
 	var args = dargs(options, ['bundleExec', 'watch', 'poll', 'sourcemapPath']);


### PR DESCRIPTION
This is in response to #75 (and similar).

It makes all paths passed to loadPath relative to procDir, which brings the behaviour of gulp-ruby-sass more in line with sass itself.

In the latest version, you either have to add all the sass files that your sass files @import to the .src glob (meaning you have to specify them twice - once in the glob, once in the sass) or you have to use absolute paths in loadPath, which is not really viable in codebases that are cloned across multiple machines.

The expected behaviour in the sass tool itself is that load_paths [defaults to the working directory](http://sass-lang.com/documentation/file.SASS_REFERENCE.html#load_paths-option).

I realise this changes the behaviour of the option, not sure if that's too much. I'd find this very useful though, so I thought I'd suggest it and see what you thought.
