### PR TITLE
Adds proper emitting of errors.

### DIFF
--- a/test.js
+++ b/test.js
@@ -45,6 +45,10 @@ it('should compile Sass with sourcemaps', function (cb) {
 		}
 	});
 
+	stream.on('error', function (err) {
+		console.log("err", err);
+	});
+
 	stream.on('end', cb);
 
 	stream.write(testFile);


### PR DESCRIPTION
As far as I can understand there are no proper way of handling errors in this module right now. All modules are suppressed and simply logged out to the console (causing the error #82 - which is a bug with this plugin). There where proper handling previously, but after changing to gulp-intermediate, this module is no longer emitting it's error. 

This adds errors the "proper way" by emitting them to the stream – allowing for errors to be caught.

_As a side note: The test is failing (and was previously due to a separate issue), and adding a listener for errors show what fails._
