### PR TITLE
Updated readme.md to reflect new Sass update, which automatically output...

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,7 @@ var sass = require('gulp-ruby-sass');
 
 gulp.task('default', function () {
     return gulp.src('src/scss/app.scss')
-        .pipe(sass(sourcemapPath: '../scss'}))
+        .pipe(sass({sourcemapPath: '../scss'}))
         .on('error', function (err) { console.log(err.message); })
         .pipe(gulp.dest('dist/css'));
 });


### PR DESCRIPTION
I was having issues after updating to the latest version of Sass and `gulp-ruby-sass`. I attempted to reference `readme.md` after receiving error messages about the deprecated `sourcemap` option, but it seemed outdated. After inspecting `index.js` it became evident to me that the code itself had been updated, but not the readme.
