### PR TITLE
Use multiline match to catch sass error message

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ module.exports = function (options) {
 	options = options || {};
 
 	// error handling
-	var sassErrMatcher = /^error/;
+	var sassErrMatcher = /^\s*error/m;
 	var noBundlerMatcher = /Gem bundler is not installed/;
 	var noGemfileMatcher = /Could not locate Gemfile/;
 	var noBundleSassMatcher = /bundler: command not found|Could not find gem/;


### PR DESCRIPTION
It is possible that multiline messages are passed to stream. In such cases, this plugin cannot catch the error and then exit normally.

Just add multiline flag to fix it.
