### PR TITLE
fix tests to work with Sass 3.4 and dargs 2.x

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ module.exports = function (options) {
 		var compileDir = slash(path.join(tempDir, relativeCompileDir));
 
 		options = options || {};
-		options.update = tempDir + ':' + compileDir;
+		options.update = true;
 		options.loadPath = typeof options.loadPath === 'undefined' ? [] : [].concat(options.loadPath);
 
 		// add loadPaths for each temp file
@@ -98,6 +98,8 @@ module.exports = function (options) {
 			'sourcemapPath',
 			'container'
 		]);
+
+		args.push(tempDir + ':' + compileDir);
 
 		if (options.bundleExec) {
 			command = 'bundle';

--- a/readme.md
+++ b/readme.md
@@ -48,10 +48,17 @@ Use [gulp-watch](https://github.com/gulpjs/gulp/blob/master/docs/API.md#gulpwatc
 
 ##### sourcemap
 
-Type: `Boolean`  
-Default: `false`
+Type: `String`  
+Default: `auto`
 
-Enable Source Map. **Requires Sass >= 3.3.0 and the [`sourcemapPath` option](#sourcemappath).**
+Values:
+
+- `auto` - relative paths where possible, file URIs elsewhere
+- `file` - always absolute file URIs
+- `inline` - include the source text in the sourcemap
+- `none`- no sourcemaps
+
+Enable Source Map. **Requires Sass >= 3.4.0 and the [`sourcemapPath` option](#sourcemappath).**
 
 
 ##### sourcemapPath

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ var assert = require('assert');
 var gulp = require('gulp');
 var sass = require('./');
 var EOL = require('os').EOL;
+var path = require('path');
 
 var addSourcemapComment = function (name, contents) {
 	return contents + EOL + '/*# sourceMappingURL=' + name + '.css.map */' + EOL;
@@ -36,7 +37,7 @@ it('compiles Sass', function (done) {
 		'fixture/nested/fixture-b.scss'
 	], { base: '.' })
 
-	.pipe(sass({ quiet: true }))
+	.pipe(sass({ quiet: true, sourcemap: 'none' }))
 
 	.on('data', function (data) {
 		files.push(data);
@@ -44,8 +45,8 @@ it('compiles Sass', function (done) {
 
 	.on('end', function () {
 		// file path
-		assert.equal(files[0].relative, 'fixture/fixture-a.css');
-		assert.equal(files[1].relative, 'fixture/nested/fixture-b.css');
+		assert.equal(files[0].relative, path.join('fixture', 'fixture-a.css'));
+		assert.equal(files[1].relative, path.join('fixture', 'nested', 'fixture-b.css'));
 
 		// css content
 		assert.equal(files[0].contents.toString(), results[0]);
@@ -70,7 +71,6 @@ it('compiles Sass with sourcemaps', function (done) {
 
 	.pipe(sass({
 		quiet: true,
-		sourcemap: true,
 		sourcemapPath: '../css'
   }))
 
@@ -100,8 +100,8 @@ it('compiles Sass with sourcemaps', function (done) {
 		// ]
 
 		// file path
-		assert.equal(files[1].relative, 'fixture/fixture-a.css.map');
-		assert.equal(files[3].relative, 'fixture/nested/fixture-b.css.map');
+		assert.equal(files[1].relative, path.join('fixture', 'fixture-a.css.map'));
+		assert.equal(files[3].relative, path.join('fixture', 'nested', 'fixture-b.css.map'));
 
 		// css content
 		assert.equal(files[0].contents.toString(), addSourcemapComment('fixture-a', results[0]));


### PR DESCRIPTION
grunt-contrib-sass has already updated to dargs 2.0.0, so I believe this should be safe enough.

This update allows one to specify the Sass 3.4's `sourcemap` option.

<hr>

**Update:**
- Some tests are failing in Windows because Vinyl files contain OS-dependent dir separators and the unit tests have forward slashes hardcoded in. I've replaced those with `path.join`;
- For the unit tests to run correctly with Sass 3.4.1 (which has sourcemaps enabled by default), we have to manually disable sourcemap generation when sourcemaps shouldn't be generated (`sourcemap: 'none'`). I'm removing `sourcemap: true` as well as that displays a deprecation warning;
- There is a conflict with dargs 2.x here that is generating an `--update=path:path` option which is not accepted by Sass. I've patched this by turning update into a boolean option and adding the `srcPath:destPath` manually to the args list.
