### PR TITLE
Fix invalid regular expressions in removePaths function.

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,6 +9,8 @@ var spawn = require('win-spawn');
 var eachAsync = require('each-async');
 var glob = require('glob');
 var intermediate = require('gulp-intermediate');
+var escapeStringRegexp = require('escape-string-regexp');
+
 
 function rewriteSourcemapPaths (compileDir, relativePath, cb) {
 	glob(path.join(compileDir, '**/*.map'), function (err, files) {
@@ -41,14 +43,10 @@ function rewriteSourcemapPaths (compileDir, relativePath, cb) {
 	});
 }
 
-function escapeRegExp(string) {
-    return string.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, '\\$1');
-}
-
 function removePaths(msg, paths) {
 	paths.forEach(function (path) {
 
-		msg = msg.replace(new RegExp(escapeRegExp(path) + '/?', 'g'), '');
+		msg = msg.replace(new RegExp(escapeStringRegexp(path) + '/?', 'g'), '');
 	});
 
 	return msg;


### PR DESCRIPTION
Just started using gulp-ruby-sass and got an invalid regular expression from file paths in the var folder.
I believe the expression needs to be escaped.

```
/node_modules/gulp-ruby-sass/index.js:46
        msg = msg.replace(new RegExp(path + '/?', 'g'), '');
                          ^
SyntaxError: Invalid regular expression: //var/folders/NR/NRG9Uc5BH-elQL4jYAdgLk+++TI/-Tmp-/gulp-ruby-sass/?/: Nothing to repeat
    at new RegExp (<anonymous>)
    at /gulp-ruby-sass/index.js:46:21
    at Array.forEach (native)
    at removePaths (/gulp_angular/node_modules/gulp-ruby-sass/index.js:45:8)
    at Socket.<anonymous> (/node_modules/gulp-ruby-sass/index.js:118:14)
    at Socket.emit (events.js:95:17)
    at Socket.<anonymous> (_stream_readable.js:764:14)
    at Socket.emit (events.js:92:17)
    at emitReadable_ (_stream_readable.js:426:10)
    at emitReadable (_stream_readable.js:422:5)
```
