### PR TITLE
Allow environment variables to be set for the sass process.

### DIFF
--- a/fixture/ext/env.rb
+++ b/fixture/ext/env.rb
@@ -1,0 +1,13 @@
+module Sass
+  module Script
+    module Functions
+      def env(key)
+        if ENV.has_key?(key.value)
+          Sass::Script::String.new(ENV[key.value])
+        else
+          Sass::Script::Null.new
+        end
+      end
+    end
+  end
+end

--- a/fixture/fixture-env.scss
+++ b/fixture/fixture-env.scss
@@ -1,0 +1,3 @@
+.env {
+  test: env("TEST");
+}

--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var eachAsync = require('each-async');
 var glob = require('glob');
 var intermediate = require('gulp-intermediate');
 var escapeStringRegexp = require('escape-string-regexp');
+var _ = require('lodash');
 
 
 function rewriteSourcemapPaths (compileDir, relativePath, cb) {
@@ -108,12 +109,17 @@ module.exports = function (options) {
 			command = 'sass';
 		}
 
+    var spawn_options = {};
+    if (options.env) {
+      spawn_options.env = _.assign({}, process.env, options.env);
+    }
+
 		// temporary logging until gulp adds its own
 		if (process.argv.indexOf('--verbose') !== -1) {
 			gutil.log('gulp-ruby-sass:', 'Running command:', chalk.blue(command, args.join(' ')));
 		}
 
-		var sass = spawn(command, args);
+		var sass = spawn(command, args, spawn_options);
 
 		sass.stdout.setEncoding('utf8');
 		sass.stderr.setEncoding('utf8');

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "gulp-intermediate": "3.0.1",
     "gulp-util": "^3.0.0",
     "slash": "^1.0.0",
-    "win-spawn": "^2.0.0"
+    "win-spawn": "^2.0.0",
+    "lodash": "^2.4.1"
   },
   "devDependencies": {
     "gulp": "^3.7.0",

--- a/test.js
+++ b/test.js
@@ -146,3 +146,24 @@ it('emits errors but still streams file on Sass error', function (done) {
 		done();
 	});
 });
+
+it('can pass environment variables', function (done) {
+	this.timeout(20000);
+
+  var files = [];
+
+	var outputMatcher = new RegExp('test:.*set');
+
+	gulp.src('fixture/fixture-env.scss')
+	
+  .pipe(sass({require: "./fixture/ext/env.rb",
+              env: {TEST: "set"}}))
+	.on('data', function (data) {
+		files.push(data);
+	})
+	.on('end', function () {
+    assert(outputMatcher.test(files[0].contents.toString()));
+		done();
+	});
+
+});


### PR DESCRIPTION
Environment variables are a common way for Sass extensions to be configured. For instance, at my work we set a LOCALE environment variable to create for per-locale output.

This allows an environment hash to be passed to the sass processor and then passes it through when the sass process is spawned.

My test fails but it's failing the same way that a bunch of the other tests are failing. I'm not sure why, but I think the test will pass if that is sorted out.
