### PR TITLE
Update index.js for sourcemap argument deprecation.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,6 +10,7 @@ var eachAsync = require('each-async');
 var glob = require('glob');
 var intermediate = require('gulp-intermediate');
 var escapeStringRegexp = require('escape-string-regexp');
+var sourcemaps = ['auto', 'file', 'inline', 'none'];
 
 
 function rewriteSourcemapPaths (compileDir, relativePath, cb) {
@@ -55,6 +56,13 @@ function createErr(err, opts) {
 	return new gutil.PluginError('gulp-ruby-sass', err, opts);
 }
 
+// Determines if a sourcemap is a valid sass sourcemap argument.
+function isValidSourcemap(sourcemap) {
+
+	return sourcemap && sourcemaps.indexOf(sourcemap) !== -1;
+
+}
+
 module.exports = function (options) {
 	var relativeCompileDir = '_14139e58-9ebe-4c0f-beca-73a65bb01ce9';
 	var procDir = process.cwd();
@@ -95,11 +103,17 @@ module.exports = function (options) {
 			'bundleExec',
 			'watch',
 			'poll',
+			'sourcemap',
 			'sourcemapPath',
 			'container'
 		]);
 
 		args.push(tempDir + ':' + compileDir);
+
+		// temporary fix for sourcemap
+		if (isValidSourcemap(options.sourcemap)) {
+			args.unshift('--sourcemap=' + options.sourcemap);
+		}
 
 		if (options.bundleExec) {
 			command = 'bundle';


### PR DESCRIPTION
When I would pass in 'inline' for 'sourcemap' option gulp would create a file named 'inline' which contained an error. This was because the formatting of the argument was incorrect. My proposed fix should work if a valid sourcemap is passed in. The argument is then passed to sass appropriately. Currently a deprecation warning is also logged to STDOUT if one passes in {sourcemap:true,sourcemapMap:''}.
