### PR TITLE
do not mutate the options object

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,7 @@ var chalk = require('chalk');
 var dargs = require('dargs');
 var slash = require('slash');
 var gutil = require('gulp-util');
+var assign = require('object-assign');
 var spawn = require('win-spawn');
 var eachAsync = require('each-async');
 var glob = require('glob');
@@ -58,7 +59,7 @@ function createErr(err, opts) {
 module.exports = function (options) {
 	var relativeCompileDir = '_14139e58-9ebe-4c0f-beca-73a65bb01ce9';
 	var procDir = process.cwd();
-	options = options || {};
+	options = assign({}, options);
 
 	// error handling
 	var sassErrMatcher = /^error/;

--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "gulp-intermediate": "3.0.1",
     "gulp-util": "^3.0.0",
     "slash": "^1.0.0",
-    "win-spawn": "^2.0.0"
+    "win-spawn": "^2.0.0",
+    "object-assign": "~1.0.0"
   },
   "devDependencies": {
     "gulp": "^3.7.0",


### PR DESCRIPTION
The code currently modifies the original 'options' object, which might be used for multiple tasks by the user. This PR fixes this.
