### PR TITLE
Force SASS to use UTF-8, even on Windows

### DIFF
--- a/index.js
+++ b/index.js
@@ -100,6 +100,18 @@ module.exports = function (options) {
 			'container'
 		]);
 
+        /**
+         * SASS will very frequently default to Ruby's default character set
+         *  for READING files (the output files all appear to be UTF-8
+         *  regardless!)
+         *  On Linux/Mac OS X the default is UTF-8, which is good.
+         *  On Windows the default is... CP1252 - oops!
+         *  Easiest way to fix this is just to force it to use UTF-8 here. All
+         *  of the other options are horrendous.
+         * @link http://blog.pixelastic.com/2014/09/06/compass-utf-8-encoding-on-windows/
+         */
+        args.push("-Eutf-8");
+
 		args.push(tempDir + ':' + compileDir);
 
 		if (options.bundleExec) {


### PR DESCRIPTION
See http://blog.pixelastic.com/2014/09/06/compass-utf-8-encoding-on-windows/

SASS uses Ruby's default character set if it can't find either a UTF-8 BOM (eww) or a `@charset` line right at the top of each .scss file (equally eww). On Linux/Mac, Ruby's default charset is UTF-8 so that isn't a problem, but on Windows it uses CP1252 for reading - and then writes in UTF-8.

End result is a file where all non-ASCII characters are completely corrupted.

As the linked article says, the best way to fix this is to force SASS to use UTF-8 by passing it the `-Eutf-8` command-line argument.

Obviously the ideal solution here would be to allow users of `gulp-ruby-sass` to specify their own charset, but this is at least good enough to fix the Windows bug...