### PR TITLE
fix absolute path resolution for sourcemaps

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,7 +183,7 @@ module.exports = function (source, options) {
 
 						// create relative paths for sources
 						sourcemap.sources = sourcemap.sources.map(function (sourcemapSource) {
-							var absoluteSourcePath = sourcemapSource.replace('file://', '');
+							var absoluteSourcePath = sourcemapSource.replace(/file:\/\/\/?/i, '').split('/').map(decodeURIComponent).join('/');
 							return path.relative(base, absoluteSourcePath);
 						});
 


### PR DESCRIPTION
Fix for #161. Using regex to replace file: protocol with 2 or 3 slashes for *nix and windows respectively. 
