### PR TITLE
Correcting example

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -27,16 +27,20 @@ You also need to have [Ruby](http://www.ruby-lang.org/en/downloads/) and [Sass](
 ```js
 var gulp = require('gulp');
 var sass = require('gulp-ruby-sass');
+var autoprefixer = require('gulp-autoprefixer');
+var sourcemaps   = require('gulp-sourcemaps');
 
 gulp.task('default', function () {
-	return gulp.src('src/scss/app.scss')
-		.pipe(sass({sourcemap: true, sourcemapPath: '../scss'}))
+	return sass('src/scss/app.scss', {sourcemap: true}))
 		.on('error', function (err) { console.log(err.message); })
+		.pipe(autoprefixer(config.autoprefixer))
+		// Add any other processors that support gulp-sourcemaps here
+		.pipe(sourcemaps.write())
 		.pipe(gulp.dest('dist/css'));
 });
 ```
 
-Add the files you want to compile to `gulp.src()`.
+`gulp.src().pipe(sass(options))` doesn't cope well with inlining sourcemaps. Use `sass(filename, options)` instead. You will need to run it separately for each source file, because sass does not yet support globbing.
 
 Handle Sass errors with an `on('error', cb)` listener or a plugin like [plumber](https://github.com/floatdrop/gulp-plumber). gulp-ruby-sass throws errors like a gulp plugin, but also passes the erroring Sass files through the stream if you prefer to see the errors in your browser.
 


### PR DESCRIPTION
I cannot get gulp-ruby-sass to produce correct inline sourcemaps if I start the stream using gulp.src, especially if I pipe it through another processor.

It took me *hours* to find the right solution. Please do keep the docs up to date with the current best practice.

I expected gulp.src to just work. And quite frankly I don't care why it doesn't. Browserify doesn't support gulp.src either.
I expected that if I did `gulp.src(filename).pipe(sass(options))` then sass would correctly find and use all necessary `@import`s and produce correct inline sourcemaps. Maybe it's not possible. I don't really care why, but please keep the docs up to date.