### PR TITLE
Prepend PID to temporary folder to be unique

### DIFF
--- a/index.js
+++ b/index.js
@@ -72,7 +72,7 @@ module.exports = function (options) {
 
 	var stream = intermediate({
 		output: relativeCompileDir,
-		container: options.container || 'gulp-ruby-sass'
+		container: options.container || path.join(process.pid.toString(), 'gulp-ruby-sass')
 	}, function (tempDir, cb, vinylFiles) {
 		// all paths passed to sass must have unix path separators
 		tempDir = slash(tempDir);


### PR DESCRIPTION
This should solve the problem when multiple instances of gulp-ruby-sass are executed in parallel on the same machine, every instance will have its own unique directory by prepending the unique PID 