### PR TITLE
Fix single file error emiting #164

### DIFF
--- a/index.js
+++ b/index.js
@@ -94,7 +94,7 @@ module.exports = function (source, options) {
 	// error handling
 	var matchNoSass = /execvp\(\): No such file or directory|spawn ENOENT/;
 	var msgNoSass = 'Missing the Sass executable. Please install and make available on your PATH.';
-	var matchSassErr = /error\s/;
+	var matchSassErr = /[e,E]rror[\s,:]/;
 	var matchNoBundler = /ERROR: Gem bundler is not installed/;
 	var matchNoGemfile = /Could not locate Gemfile/;
 	var matchNoBundledSass = /bundler: command not found: sass|Could not find gem/;
@@ -134,8 +134,15 @@ module.exports = function (source, options) {
 	// spawn stderr: no sass executable
 	sass.stderr.on('data', function (data) {
 		var msg = formatMsg(data, destDir);
+		
+		var isError = [
+			matchSassErr,
+			matchNoBundledSass
+		].some(function (match) {
+			return match.test(msg);
+		});
 
-		if (matchNoBundledSass.test(msg)) {
+		if (isError) {
 			stream.emit('error', newErr(msg));
 		}
 		else if (!matchNoSass.test(msg)) {

--- a/test.js
+++ b/test.js
@@ -236,13 +236,65 @@ it('outputs correct sourcemap paths for files and paths containing spaces', func
 	});
 });
 
-it('emits errors but streams file on Sass error', function (done) {
+it('emits errors but streams file on Sass error (directory)', function (done) {
 	this.timeout(20000);
+	
+	var errorEvent = false;
+	var dataEvent = false;
+	var endEvent = false;
 
 	var matchErrMsg = new RegExp('File to import not found or unreadable: i-dont-exist.');
 	var errFileExists;
 
+	setTimeout(function () {
+    assert(errorEvent, 'Error event did not fire in 1000 ms.');
+		assert(dataEvent, 'Data event did not fire in 1000 ms.');
+		assert(endEvent, 'End event did not fire in 1000 ms.');
+    done();
+  }, 2000);
+
 	sass('fixture/source', {
+		quiet: true,
+		unixNewlines: true,
+		verbose: true
+	})
+
+	.on('error', function (err) {
+		// throws an error
+		assert(matchErrMsg.test(err.message));
+		errorEvent = true;
+	})
+
+	.on('data', function (file) {
+		// streams the erroring css file
+		errFileExists = errFileExists || matchErrMsg.test(file.contents.toString());
+		dataEvent = true;
+	})
+
+	.on('end', function () {
+		assert(errFileExists);
+		endEvent = true;
+	});
+});
+
+it('emits errors but streams file on Sass error (single file)', function (done) {
+	this.timeout(20000);
+	
+	var errorEvent = false;
+	var dataEvent = false;
+	var endEvent = false;
+
+	var matchErrMsg = new RegExp('File to import not found or unreadable: i-dont-exist.');
+	var errFileExists;
+
+	setTimeout(function () {
+    assert(errorEvent, 'Error event did not fire in 1000 ms.');
+		assert(dataEvent, 'Data event did not fire in 1000 ms.');
+		assert(endEvent, 'End event did not fire in 1000 ms.');
+    done();
+  }, 2000);
+
+	sass('fixture/source/fixture-error.scss', {
 		quiet: true,
 		unixNewlines: true
 	})
@@ -250,15 +302,17 @@ it('emits errors but streams file on Sass error', function (done) {
 	.on('error', function (err) {
 		// throws an error
 		assert(matchErrMsg.test(err.message));
+		errorEvent = true;
 	})
 
 	.on('data', function (file) {
 		// streams the erroring css file
 		errFileExists = errFileExists || matchErrMsg.test(file.contents.toString());
+		dataEvent = true;
 	})
 
 	.on('end', function () {
 		assert(errFileExists);
-		done();
+		endEvent = true;
 	});
 });


### PR DESCRIPTION
Hello,

I open pull request for issue #164.

Sass output errors from single file compilation to stderr and from directory compilation to stdout. (messages are in slightly different format).

I add test for single file compilation, but there is still strange behaviour. Directory test is failing, because no .on('error') event is emitted. But when I run this plugin with Gulp, directory and single file compilation error emitting now works as expected. So I don't know what can be wrong. (OS X 10.10, node 0.12.0, sass 3.4.13)