### PR TITLE
loadPath still supports an Array

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -142,10 +142,10 @@ The docs below list common options for convenience. Run `sass -h` for the comple
 
 #### loadPath
 
-Type: `String`  
+Type: `String|Array`  
 Default: `false`
 
-Specify a Sass import path.
+Specify one or more Sass import paths.
 
 #### require
 


### PR DESCRIPTION
I checked with `verbose: true`, and passing an array to the loadPath key adds all the `--loadPath` parameters to the command.