### PR TITLE
Improve and extract logging and error handling to its own file

### DIFF
--- a/fixture/Gemfile
+++ b/fixture/Gemfile
@@ -1,0 +1,2 @@
+source 'https://rubygems.org'
+gem 'sass', '~> 3.4'

--- a/fixture/Gemfile.lock
+++ b/fixture/Gemfile.lock
@@ -1,0 +1,10 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    sass (3.4.13)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  sass (~> 3.4)

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = function (source, options) {
 	var command;
 	var args;
 	var base;
-	var destDir;
+	var tempDir;
 	var destFile;
 	var compileMappings;
 
@@ -49,20 +49,20 @@ module.exports = function (source, options) {
 	options.sourcemap = options.sourcemap === true ? 'file' : 'none';
 
 	// sass options need unix style slashes
-	destDir = slash(path.join(osTempDir, options.container));
+	tempDir = slash(path.join(osTempDir, options.container));
 
 	// directory source
 	if (path.extname(source) === '') {
 		base = path.join(cwd, source);
-		compileMappings = source + ':' + destDir;
+		compileMappings = source + ':' + tempDir;
 		options.update = true;
 	}
 	// single file source
 	else {
 		base = path.join(cwd, path.dirname(source));
-		destFile = slash(path.join(destDir, path.basename(source, path.extname(source)) + '.css')); // sass options need unix style slashes
+		destFile = slash(path.join(tempDir, path.basename(source, path.extname(source)) + '.css')); // sass options need unix style slashes
 		compileMappings = [ source, destFile ];
-		mkdirp(destDir);
+		mkdirp(tempDir);
 	}
 	// TODO: implement glob file source
 
@@ -92,11 +92,11 @@ module.exports = function (source, options) {
 	sass.stderr.setEncoding('utf8');
 
 	sass.stdout.on('data', function (data) {
-		logger.stdout(data, destDir, stream);
+		logger.stdout(data, tempDir, stream);
 	});
 
 	sass.stderr.on('data', function (data) {
-		logger.stderr(data, destDir, stream);
+		logger.stderr(data, tempDir, stream);
 	});
 
 	sass.on('error', function (err) {
@@ -104,7 +104,7 @@ module.exports = function (source, options) {
 	});
 
 	sass.on('close', function (code) {
-		glob(path.join(destDir, '**', '*'), function (err, files) {
+		glob(path.join(tempDir, '**', '*'), function (err, files) {
 			if (err) {
 				stream.emit('error', new gutil.PluginError('gulp-ruby-sass', err));
 			}
@@ -127,7 +127,7 @@ module.exports = function (source, options) {
 					var vinylFile = new File({
 						cwd: cwd,
 						base: base,
-						path: file.replace(destDir, base)
+						path: file.replace(tempDir, base)
 					});
 					var sourcemap;
 
@@ -156,7 +156,7 @@ module.exports = function (source, options) {
 				// TODO: This kills caching. Keeping will push files through that are not in
 				// the current gulp.src. We need to decide whether to use a Sass style caching
 				// strategy, or a gulp style strategy, and what each would look like.
-				rimraf(destDir, function () {
+				rimraf(tempDir, function () {
 					stream.push(null);
 				});
 			});

--- a/index.js
+++ b/index.js
@@ -14,20 +14,10 @@ var convert = require('convert-source-map');
 var eachAsync = require('each-async');
 var osTempDir = require('os').tmpdir();
 
+var logger = require('./logger')
+
 var File = require('vinyl');
 var Readable = require('stream').Readable;
-
-// remove temp directory and line breaks for more Sass-like logging
-function formatMsg (msg, tempDir) {
-	msg = msg.replace(new RegExp((tempDir) + '/?', 'g'), '');
-	msg = msg.trim();
-	return msg;
-}
-
-// convenience function to create a gulp error
-function newErr (err, opts) {
-	return new gutil.PluginError('gulp-ruby-sass', err, opts);
-}
 
 // for now, source is only a single directory or a single file
 module.exports = function (source, options) {
@@ -91,17 +81,9 @@ module.exports = function (source, options) {
 		command = 'sass';
 	}
 
-	// error handling
-	var matchNoSass = /execvp\(\): No such file or directory|spawn ENOENT/;
-	var msgNoSass = 'Missing the Sass executable. Please install and make available on your PATH.';
-	var matchSassErr = /error\s/;
-	var matchNoBundler = /ERROR: Gem bundler is not installed/;
-	var matchNoGemfile = /Could not locate Gemfile/;
-	var matchNoBundledSass = /bundler: command not found: sass|Could not find gem/;
-
 	// plugin logging
 	if (options.verbose) {
-		gutil.log('gulp-ruby-sass', 'Running command:', command, args.join(' '));
+		logger.verbose(command, args);
 	}
 
 	var sass = spawn(command, args);
@@ -109,46 +91,16 @@ module.exports = function (source, options) {
 	sass.stdout.setEncoding('utf8');
 	sass.stderr.setEncoding('utf8');
 
-	// sass stdout: successful compile messages
-	// bundler stdout: bundler not installed, no gemfile, correct version of sass not installed
 	sass.stdout.on('data', function (data) {
-		var msg = formatMsg(data, destDir);
-		var isError = [
-			matchSassErr,
-			matchNoBundler,
-			matchNoGemfile,
-			matchNoBundledSass
-		].some(function (match) {
-			return match.test(msg);
-		});
-
-		if (isError) {
-			stream.emit('error', newErr(msg));
-		} else {
-			gutil.log('gulp-ruby-sass stdout:', msg);
-		}
+		logger.stdout(data, destDir, stream);
 	});
 
-	// sass stderr: warnings, debug statements
-	// bundler stderr: no version of sass installed
-	// spawn stderr: no sass executable
 	sass.stderr.on('data', function (data) {
-		var msg = formatMsg(data, destDir);
-
-		if (matchNoBundledSass.test(msg)) {
-			stream.emit('error', newErr(msg));
-		}
-		else if (!matchNoSass.test(msg)) {
-			gutil.log('gulp-ruby-sass stderr:', msg);
-		}
+		logger.stderr(data, destDir, stream);
 	});
 
-	// spawn error: no sass executable
 	sass.on('error', function (err) {
-		if (matchNoSass.test(err)) {
-			err.message = msgNoSass;
-		}
-		stream.emit('error', newErr(err));
+		logger.error(err, stream);
 	});
 
 	sass.on('close', function (code) {

--- a/logger.js
+++ b/logger.js
@@ -1,0 +1,80 @@
+'use strict';
+var gutil = require('gulp-util');
+
+// Remove temp directory for more Sass-like logging
+function prettifyDirectoryLogging (msg, tempDir) {
+	return msg.replace(new RegExp((tempDir) + '/?', 'g'), './');
+}
+
+module.exports = {
+	verbose: function  (command, args) {
+		console.log("Running command " + command + " " + args.join(" "));
+	},
+
+	stdout: function (data, tempDir, stream) {
+		// Bundler error: no Sass version found
+		if (/bundler: command not found: sass/.test(data)) {
+			stream.emit('error', new Error("bundler: command not found: sass"));
+		}
+
+		// Bundler error: Gemfile not found
+		else if (/Could not locate Gemfile or .bundle\/ directory/.test(data)) {
+			stream.emit('error', new Error("bundler: could not locate Gemfile or .bundle directory"));
+		}
+
+		// Sass error: directory missing
+		else if (/No such file or directory @ rb_sysopen/.test(data)) {
+			stream.emit('error', new Error(data.trim()));
+		}
+
+		// Not an error: Sass logging
+		else {
+			data = prettifyDirectoryLogging(data, tempDir);
+			data = data.trim()
+			console.log(data);
+		}
+	},
+
+	stderr: function (data, tempDir, stream) {
+		var bundlerMissing = /Could not find 'bundler' \((.*?)\)/.exec(data)
+		var sassVersionMissing = /Could not find gem 'sass \((.*?)\) ruby'/.exec(data)
+
+		// Ruby error: Bundler gem not installed
+		if (bundlerMissing) {
+			stream.emit('error', new Error(
+				"ruby: Could not find 'bundler' (" + bundlerMissing[1] + ")."
+			));
+		}
+
+		// Bundler error: no matching Sass version
+		else if (sassVersionMissing) {
+			stream.emit('error', new Error(
+				"bundler: Could not find gem 'sass (" + sassVersionMissing[1] + ")'."
+			));
+		}
+
+		// Sass error: file missing
+		else if (/No such file or directory @ rb_sysopen/.test(data)) {
+			stream.emit('error', new Error(data.trim()));
+		}
+
+		// Not an error: Sass warnings, debug statements
+		else {
+			data = prettifyDirectoryLogging(data, tempDir);
+			data = data.trim()
+			console.log(data);
+		}
+	},
+
+	error: function (err, stream) {
+		// Spawn error: bundle or sass not installed
+		if (err.code === 'ENOENT') {
+			stream.emit('error', new Error('Gem ' + err.path + ' is not installed.'));
+		}
+
+		// Other errors
+		else {
+			stream.emit(err);
+		}
+	}
+}

--- a/logger.js
+++ b/logger.js
@@ -8,30 +8,36 @@ function prettifyDirectoryLogging (msg, tempDir) {
 
 module.exports = {
 	verbose: function  (command, args) {
-		console.log("Running command " + command + " " + args.join(" "));
+		gutil.log('Running command ' + command + ' ' + args.join(' '));
 	},
 
 	stdout: function (data, tempDir, stream) {
 		// Bundler error: no Sass version found
 		if (/bundler: command not found: sass/.test(data)) {
-			stream.emit('error', new Error("bundler: command not found: sass"));
+			stream.emit('error', new gutil.PluginError(
+				'gulp-ruby-sass',
+				'bundler: command not found: sass'
+			));
 		}
 
 		// Bundler error: Gemfile not found
 		else if (/Could not locate Gemfile or .bundle\/ directory/.test(data)) {
-			stream.emit('error', new Error("bundler: could not locate Gemfile or .bundle directory"));
+			stream.emit('error', new gutil.PluginError(
+				'gulp-ruby-sass',
+				'bundler: could not locate Gemfile or .bundle directory'
+			));
 		}
 
 		// Sass error: directory missing
 		else if (/No such file or directory @ rb_sysopen/.test(data)) {
-			stream.emit('error', new Error(data.trim()));
+			stream.emit('error', new gutil.PluginError('gulp-ruby-sass', data.trim()));
 		}
 
 		// Not an error: Sass logging
 		else {
 			data = prettifyDirectoryLogging(data, tempDir);
 			data = data.trim()
-			console.log(data);
+			gutil.log(data);
 		}
 	},
 
@@ -41,35 +47,40 @@ module.exports = {
 
 		// Ruby error: Bundler gem not installed
 		if (bundlerMissing) {
-			stream.emit('error', new Error(
-				"ruby: Could not find 'bundler' (" + bundlerMissing[1] + ")."
+			stream.emit('error', new gutil.PluginError(
+				'gulp-ruby-sass',
+				'ruby: Could not find \'bundler\' (' + bundlerMissing[1] + ').'
 			));
 		}
 
 		// Bundler error: no matching Sass version
 		else if (sassVersionMissing) {
-			stream.emit('error', new Error(
-				"bundler: Could not find gem 'sass (" + sassVersionMissing[1] + ")'."
+			stream.emit('error', new gutil.PluginError(
+				'gulp-ruby-sass',
+				'bundler: Could not find gem \'sass (' + sassVersionMissing[1] + ')\'.'
 			));
 		}
 
 		// Sass error: file missing
 		else if (/No such file or directory @ rb_sysopen/.test(data)) {
-			stream.emit('error', new Error(data.trim()));
+			stream.emit('error', new gutil.PluginError('gulp-ruby-sass', data.trim()));
 		}
 
 		// Not an error: Sass warnings, debug statements
 		else {
 			data = prettifyDirectoryLogging(data, tempDir);
 			data = data.trim()
-			console.log(data);
+			gutil.log(data);
 		}
 	},
 
 	error: function (err, stream) {
 		// Spawn error: bundle or sass not installed
 		if (err.code === 'ENOENT') {
-			stream.emit('error', new Error('Gem ' + err.path + ' is not installed.'));
+			stream.emit('error', new gutil.PluginError(
+				'gulp-ruby-sass',
+				'Gem ' + err.path + ' is not installed.'
+			));
 		}
 
 		// Other errors

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "dargs": "^2.0.3",
     "each-async": "^1.0.0",
     "glob": "^4.0.2",
-    "gulp-util": "^3.0.0",
+    "gulp-util": "^3.0.4",
     "mkdirp": "^0.5.0",
     "object-assign": "^2.0.0",
     "rimraf": "^2.2.8",


### PR DESCRIPTION
The error handling between gulp, sass, bundler, and spawn / the OS is complicated. This extracts logging and error handling into a separate, well documented file, and expands the coverage for `file:file` and `--update` errors — Sass reports missing source for one on stderr and one on stdout :P.

No tests right now, but I'd like to add them in a separate PR. The environment set up and tear down will be a pain, but every time there's an error in this part of the plugin I spend and hour manually testing. 

Starting another PR based on this one for throwing Sass syntax errors as errors.

This fixes #164, and does some of the things that #211 does. @adammockor, can you give your opinion on this PR? Sorry I was already halfway done with this refactor when you submitted your PR.