### PR TITLE
Removed need of the container option for parallel builds

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,7 @@ var osTmpdir = require('os-tmpdir');
 var pathExists = require('path-exists');
 var File = require('vinyl');
 var logger = require('./logger');
+var md5Hex = require('md5-hex');
 
 // for now, source is only a single directory or a single file
 module.exports = function (source, options) {
@@ -23,7 +24,6 @@ module.exports = function (source, options) {
 	var cwd = process.cwd();
 	var defaults = {
 		tempDir: osTmpdir(),
-		container: 'gulp-ruby-sass',
 		verbose: false,
 		sourcemap: false
 	};
@@ -47,8 +47,13 @@ module.exports = function (source, options) {
 	// reassign options.sourcemap boolean to one of our two acceptable Sass arguments
 	options.sourcemap = options.sourcemap === true ? 'file' : 'none';
 
+	// create temporary directory path for the task using current working
+	// directory, source and options
 	// sass options need unix style slashes
-	intermediateDir = slash(path.join(options.tempDir, options.container));
+	intermediateDir = slash(path.join(
+		options.tempDir,
+		'gulp-ruby-sass-' + md5Hex(process.cwd()) + md5Hex(source + JSON.stringify(options))
+	));
 
 	// directory source
 	if (path.extname(source) === '') {
@@ -70,7 +75,6 @@ module.exports = function (source, options) {
 		'watch',
 		'poll',
 		'tempDir',
-		'container',
 		'verbose'
 	]).concat(compileMappings);
 

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "each-async": "^1.0.0",
     "glob": "^5.0.5",
     "gulp-util": "^3.0.4",
+    "md5-hex": "^1.0.2",
     "mkdirp": "^0.5.0",
     "object-assign": "^2.0.0",
     "os-tmpdir": "^1.0.0",

--- a/readme.md
+++ b/readme.md
@@ -112,36 +112,6 @@ Default: the OS temp directory as reported by [os-tempDir](https://github.com/si
 
 This plugin compiles Sass files to a temporary directory before pushing them through the stream. Use `tempDir` to choose an alternate directory if you aren't able to use the default OS temporary directory.
 
-#### container
-
-Type: `String`  
-Default: `gulp-ruby-sass`
-
-If you only have a single gulp-ruby-sass task you can ignore this option. If you're running multiple gulp-ruby-sass tasks at once you must specify a separate `container` for each task to avoid file collisions. The value is appended to the `tempDir` option.
-
-```js
-var gulp = require('gulp');
-var sass = require('gulp-ruby-sass');
-
-gulp.task('sass-app', function () {
-	return sass('source/app.scss', {container: 'app'})
-		.on('error', function (err) {
-			console.error('Error!', err.message);
-		})
-		.pipe(gulp.dest('result/app'));
-});
-
-gulp.task('sass-site', function () {
-	return sass('source/site.scss', {container: 'site'})
-		.on('error', function (err) {
-			console.error('Error!', err.message);
-		})
-		.pipe(gulp.dest('result/site'));
-});
-
-gulp.task('sass', ['sass-app', 'sass-site']);
-```
-
 ### Sass options
 
 Any other options are passed directly to the Sass executable. The options are camelCase versions of Sass's dashed-case options.


### PR DESCRIPTION
Changed use of temporary directory. Now all builds have own unique temporary directory which is cleaned after build.

This change prevents issues with parallel build jobs, that do not define container option, as it is no longer needed at all.