### PR TITLE
Sass Caching

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,10 @@ function emitErr (stream, err) {
 	stream.emit('error', new gutil.PluginError('gulp-ruby-sass', err));
 };
 
+function cacheDirectory (tempDir) {
+	return path.join(tempDir, 'gulp-ruby-sass');
+};
+
 function uniqueIntermediateDirectory (tempDir, source) {
 	return slash(path.join(
 		tempDir,

--- a/index.js
+++ b/index.js
@@ -17,26 +17,15 @@ var osTmpdir = require('os-tmpdir');
 var pathExists = require('path-exists');
 
 var logger = require('./logger');
+var utils = require('./utils');
+
+var cacheDirectory = utils.cacheDirectory
+var emitErr = utils.emitErr
+var uniqueIntermediateDirectory = utils.uniqueIntermediateDirectory
 
 var sharedDefaults = {
 	tempDir: osTmpdir()
 }
-
-function emitErr (stream, err) {
-	stream.emit('error', new gutil.PluginError('gulp-ruby-sass', err));
-};
-
-function cacheDirectory (tempDir) {
-	return path.join(tempDir, 'gulp-ruby-sass');
-};
-
-function uniqueIntermediateDirectory (tempDir, source) {
-	return path.join(
-		tempDir,
-		'gulp-ruby-sass',
-		'cwd-' + md5Hex(process.cwd()) + '-source-' + md5Hex(source)
-	));
-};
 
 function gulpRubySass (source, options) {
 	var cwd = process.cwd();

--- a/index.js
+++ b/index.js
@@ -222,4 +222,4 @@ gulpRubySass.clearCache = function (source, tempDir, done) {
 	}
 };
 
-module.exports = gulpRubySass
+module.exports = gulpRubySass;

--- a/index.js
+++ b/index.js
@@ -18,6 +18,10 @@ var pathExists = require('path-exists');
 
 var logger = require('./logger');
 
+var sharedDefaults = {
+	tempDir: osTmpdir()
+}
+
 function emitErr (stream, err) {
 	stream.emit('error', new gutil.PluginError('gulp-ruby-sass', err));
 };
@@ -33,7 +37,7 @@ function uniqueIntermediateDirectory (tempDir, source) {
 function gulpRubySass (source, options) {
 	var cwd = process.cwd();
 	var defaults = {
-		tempDir: osTmpdir(),
+		tempDir: sharedDefaults.tempDir,
 		verbose: false,
 		sourcemap: false,
 		emitCompileError: false

--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ function cacheDirectory (tempDir) {
 };
 
 function uniqueIntermediateDirectory (tempDir, source) {
-	return slash(path.join(
+	return path.join(
 		tempDir,
 		'gulp-ruby-sass',
 		'cwd-' + md5Hex(process.cwd()) + '-source-' + md5Hex(source)
@@ -75,7 +75,6 @@ function gulpRubySass (source, options) {
 
 	// create temporary directory path for the task using current working
 	// directory, source and options
-	// sass options need unix style slashes
 	var intermediateDir = uniqueIntermediateDirectory(options.tempDir, source);
 	var base;
 	var compileMapping;
@@ -83,7 +82,8 @@ function gulpRubySass (source, options) {
 	// directory source
 	if (path.extname(source) === '') {
 		base = path.join(cwd, source);
-		compileMapping = source + ':' + intermediateDir;
+		// sass options need unix style slashes
+		compileMapping = source + ':' + slash(intermediateDir);
 		options.update = true;
 	}
 
@@ -91,13 +91,13 @@ function gulpRubySass (source, options) {
 	else {
 		base = path.join(cwd, path.dirname(source));
 
-		// sass options need unix style slashes
-		var dest = slash(path.join(
+		var dest = path.join(
 			intermediateDir,
 			gutil.replaceExtension(path.basename(source), '.css')
-		));
+		);
 
-		compileMapping = [ source, dest ];
+		// sass options need unix style slashes
+		compileMapping = [ source, slash(dest) ];
 
 		// sass's single file compilation doesn't create a destination directory, so
 		// we have to ourselves

--- a/index.js
+++ b/index.js
@@ -20,7 +20,15 @@ var logger = require('./logger');
 
 function emitErr (stream, err) {
 	stream.emit('error', new gutil.PluginError('gulp-ruby-sass', err));
-}
+};
+
+function uniqueIntermediateDirectory (tempDir, source) {
+	return slash(path.join(
+		tempDir,
+		'gulp-ruby-sass',
+		'cwd-' + md5Hex(process.cwd()) + '-source-' + md5Hex(source)
+	));
+};
 
 function gulpRubySass (source, options) {
 	var cwd = process.cwd();
@@ -60,10 +68,7 @@ function gulpRubySass (source, options) {
 	// create temporary directory path for the task using current working
 	// directory, source and options
 	// sass options need unix style slashes
-	var intermediateDir = slash(path.join(
-		options.tempDir,
-		'gulp-ruby-sass-' + md5Hex(cwd) + md5Hex(source + JSON.stringify(options))
-	));
+	var intermediateDir = uniqueIntermediateDirectory(options.tempDir, source);
 	var base;
 	var compileMapping;
 

--- a/index.js
+++ b/index.js
@@ -193,13 +193,7 @@ function gulpRubySass (source, options) {
 					return;
 				});
 			}, function () {
-				// cleanup previously generated files for next run
-				// TODO: This kills caching. Keeping will push files through that are not in
-				// the current gulp.src. We need to decide whether to use a Sass style caching
-				// strategy, or a gulp style strategy, and what each would look like.
-				rimraf(intermediateDir, function () {
-					stream.push(null);
-				});
+				stream.push(null);
 			});
 		});
 	});
@@ -207,10 +201,25 @@ function gulpRubySass (source, options) {
 	return stream;
 };
 
-gulpRubySass.logError = function logError(err) {
+gulpRubySass.logError = function (err) {
   var message = new gutil.PluginError('gulp-ruby-sass', err);
   process.stderr.write(message + '\n');
   this.emit('end');
+};
+
+gulpRubySass.clearCache = function (source, tempDir, done) {
+	tempDir = tempDir || sharedDefaults.tempDir;
+
+	// clear either a single source's intermediate dir or the entire grs cache
+	var dir = source ? uniqueIntermediateDirectory(tempDir, source) : cacheDirectory(tempDir);
+
+	// Run async if a callback was passed, sync if not
+	if (done) {
+		rimraf(dir, done);
+	}
+	else {
+		rimraf.sync(dir);
+	}
 };
 
 module.exports = gulpRubySass

--- a/logger.js
+++ b/logger.js
@@ -1,9 +1,6 @@
 'use strict';
 var gutil = require('gulp-util');
-
-function emitErr (stream, err) {
-	stream.emit('error', new gutil.PluginError('gulp-ruby-sass', err));
-}
+var emitErr = require('./utils').emitErr
 
 // Remove intermediate directory for more Sass-like logging
 function prettifyDirectoryLogging (msg, intermediateDir) {

--- a/readme.md
+++ b/readme.md
@@ -116,6 +116,50 @@ gulp.task('sass', function () {
 });
 ```
 
+### sass.clearCache([source, tempDir, done])
+
+To enable Sass caching this plugin must keep a cache of each task's compiled files in a temporary directory. 
+
+Usually this works with no further user input. BUT, if you're compiling a directory and rename or delete source files you will need to run the `clearCache` function to prevent stale files from being piped through the stream.
+
+```js
+var sass = require('gulp-ruby-sass');
+
+gulp.task('sass-theme', function () {
+  return sass('theme/source').pipe(gulp.dest('result'));
+});
+
+gulp.task('sass-app', function () {
+  return sass('app/source').pipe(gulp.dest('result'));
+});
+
+gulp.task('clear-theme-cache', function () {
+  return sass.clearCache('theme/source');
+});
+
+gulp.task('clear-all-caches', function () {
+  return sass.clearCache();
+});
+```
+
+#### source
+
+Type: `string`
+
+The source of the task who's cache should be cleared. If no source is given `clearCache` will delete the cache for all gulp-ruby-sass tasks run from the current directory.
+
+#### tempDir
+
+Type: `string`
+
+If a gulp-ruby-sass task has the [`tempDir`](#tempdir) option set it must be passed to `clearCache`.
+
+#### done
+
+Type: `function`
+
+Pass a `done` callback to make the `clearCache` function asynchronous. If no function is provided the sync version of `clearCache` will be used.
+
 ## Issues
 
 This plugin wraps the Sass gem for the gulp build system. It does not alter Sass's output in any way. Any issues with Sass output should be reported to the [Sass issue tracker](https://github.com/sass/sass/issues).

--- a/readme.md
+++ b/readme.md
@@ -99,7 +99,7 @@ Log the spawned Sass or Bundler command. Useful for debugging.
 
 ##### Sass options
 
-Any additional options are passed directly to the Sass executable. The options are camelCase versions of Sass's options parsed by [dargs](https://github.com/sindresorhus/dargs).
+Any additional options are passed directly to the Sass executable. Options are camelCase versions of Sass's options (parsed by [dargs](https://github.com/sindresorhus/dargs)).
 
 Run `sass -h` for a complete list of Sass options.
 

--- a/utils.js
+++ b/utils.js
@@ -1,0 +1,23 @@
+'use strict';
+var path = require('path');
+var md5Hex = require('md5-hex');
+var gutil = require('gulp-util');
+
+var utils = {};
+
+utils.emitErr = function (stream, err) {
+	stream.emit('error', new gutil.PluginError('gulp-ruby-sass', err));
+};
+
+utils.cacheDirectory = function (tempDir) {
+	return path.join(tempDir, 'gulp-ruby-sass');
+};
+
+utils.uniqueIntermediateDirectory = function (tempDir, source) {
+	return path.join(
+		utils.cacheDirectory(tempDir),
+		'cwd-' + md5Hex(process.cwd()) + '-source-' + md5Hex(source)
+	);
+};
+
+module.exports = utils;


### PR DESCRIPTION
Implements incremental builds using Sass's caching mechanism. Adds a `clearCache` function to clear the intermediate compilation directory that may contain outdated file names (if you rename or remove Sass source files).

Breaking changes due to no longer clearing intermediate cache on every run. Closing to re-open against 2.0.
