### PR TITLE
Extract the OS temp dir to its own option, separate from container

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-ruby-sass",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Compile Sass to CSS with Ruby Sass",
   "license": "MIT",
   "repository": "sindresorhus/gulp-ruby-sass",

--- a/readme.md
+++ b/readme.md
@@ -105,19 +105,26 @@ gulp.task('sass', function() {
 });
 ```
 
+#### tempDir
+
+Type: `String`  
+Default: the OS temp directory as reported by [os-tempDir](https://github.com/sindresorhus/os-tmpdir)
+
+This plugin compiles Sass files to a temporary directory before pushing them through the stream. Use `tempDir` to choose an alternate directory if you aren't able to use the default OS temporary directory.
+
 #### container
 
 Type: `String`  
 Default: `gulp-ruby-sass`
 
-Name of the temporary directory used to process files. If you're running multiple instances of gulp-ruby-sass at once, specify a separate container for each task to avoid files mixing together.
+If you only have a single gulp-ruby-sass task you can ignore this option. If you're running multiple gulp-ruby-sass tasks at once you must specify a separate `container` for each task to avoid file collisions. The value is appended to the `tempDir` option.
 
 ```js
 var gulp = require('gulp');
 var sass = require('gulp-ruby-sass');
 
 gulp.task('sass-app', function () {
-	return sass('source/app.scss', {container: 'gulp-ruby-sass-app'})
+	return sass('source/app.scss', {container: 'app'})
 		.on('error', function (err) {
 			console.error('Error!', err.message);
 		})
@@ -125,7 +132,7 @@ gulp.task('sass-app', function () {
 });
 
 gulp.task('sass-site', function () {
-	return sass('source/site.scss', {container: 'gulp-ruby-sass-site'})
+	return sass('source/site.scss', {container: 'site'})
 		.on('error', function (err) {
 			console.error('Error!', err.message);
 		})


### PR DESCRIPTION
The use cases for changing the OS temp dir are different from the use cases for
specifying a task-specific container. Let's decouple them for better user
interface.

Need to change temp dir use cases:
- No access to the OS temp dir due to permissions
  (reported in windows and on-server issues)
- OS temp dir is reported incorrectly
  (Windows, https://github.com/sindresorhus/gulp-ruby-sass/issues/2301)

Need to specify container use cases:
- multiple grs tasks running at once