### PR TITLE
Steal gulp-sass's logger

### DIFF
--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var logger = require('./logger');
 var md5Hex = require('md5-hex');
 
 // for now, source is only a single directory or a single file
-module.exports = function (source, options) {
+function gulpRubySass (source, options) {
 	var stream = new Readable({objectMode: true});
 	var cwd = process.cwd();
 	var defaults = {
@@ -187,3 +187,11 @@ module.exports = function (source, options) {
 
 	return stream;
 };
+
+gulpRubySass.logError = function logError(err) {
+  var message = new gutil.PluginError('gulp-ruby-sass', err);
+  process.stderr.write(message + '\n');
+  this.emit('end');
+};
+
+module.exports = gulpRubySass

--- a/readme.md
+++ b/readme.md
@@ -24,7 +24,9 @@ $ npm install --save-dev gulp-ruby-sass
 
 ## Usage
 
-Use gulp-ruby-sass instead of `gulp.src` to compile a file or directory.  
+Use gulp-ruby-sass instead of `gulp.src` to compile a file or directory.
+
+Catch errors with an `on('error', cb)` listener. You can use the plugin's `logError` method to log pretty errors to your console. Erroring files will still be streamed unless you use Sass's `stopOnError` option.
 
 ```js
 var gulp = require('gulp');
@@ -32,9 +34,7 @@ var sass = require('gulp-ruby-sass');
 
 gulp.task('sass', function () {
 	return sass('source/')
-		.on('error', function (err) {
-			console.error('Error!', err.message);
-		})
+		.on('error', sass.logError)
 		.pipe(gulp.dest('result'));
 });
 ```
@@ -42,10 +42,6 @@ gulp.task('sass', function () {
 #### Recompiling on changes
 
 Use [gulp-watch](https://github.com/gulpjs/gulp/blob/master/docs/API.md#gulpwatchglob--opts-tasks-or-gulpwatchglob--opts-cb) to automatically recompile your files on change.
-
-#### Handling errors
-
-Handle Sass errors with an `on('error', cb)` listener. gulp-ruby-sass throws errors like a gulp plugin, but streams the erroring files so you can see Sass errors in your browser too.
 
 ### Plugin options
 
@@ -79,9 +75,7 @@ var sourcemaps = require('gulp-sourcemaps');
 
 gulp.task('sass', function () {
 	return sass('source', {sourcemap: true})
-		.on('error', function (err) {
-			console.error('Error!', err.message);
-		})
+		.on('error', sass.logError)
 		.pipe(sourcemaps.write())
 		.pipe(gulp.dest('result'));
 });
@@ -92,9 +86,7 @@ gulp.task('sass', function () {
 ```js
 gulp.task('sass', function() {
 	return sass('source', { sourcemap: true })
-	.on('error', function (err) {
-	  console.error('Error', err.message);
-   })
+	.on('error', sass.logError)
 
 	.pipe(sourcemaps.write('maps', {
 		includeContent: false,
@@ -124,7 +116,7 @@ gulp.task('sass', function () {
 	return sass('source', { emitCompileError: true })
 
 	.on('error', function(err) {
-		console.error('Error', err.message);
+		sass.logError(err);
 		process.exit(1); // exit the stream immediately
 	})
 


### PR DESCRIPTION
I really enjoy the gulp-sass error logger (noticed first in Web Starter Kit). It shortens and abstracts logging a pretty error to the console, and improves task readability.

It's also a decent idea to have as similar an interface to gulp-sass as possible to ease switching between the two plugins depending on a user's requirements. Ideally, they'd only have to change their require statement.

Usage example: 

```js
gulp.task('sass', function () {
    return sass('source/')
        .on('error', sass.logError)
        .pipe(gulp.dest('result'));
});
```

Dependent on #245 