### PR TITLE
Readme improvements

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,12 +46,12 @@ function gulpRubySass (source, options) {
 
 	// error if user tries to watch their files with the Sass gem
 	if (options.watch || options.poll) {
-		throw new Error('`watch` and `poll` are not valid options for gulp-ruby-sass. Use `gulp.watch` to rebuild your files on change.');
+		emitErr(stream, '`watch` and `poll` are not valid options for gulp-ruby-sass. Use `gulp.watch` to rebuild your files on change.');
 	}
 
 	// error if user tries to pass a Sass option to sourcemap
 	if (typeof options.sourcemap !== 'boolean') {
-		throw new Error('The sourcemap option must be true or false. See the readme for instructions on using Sass sourcemaps with gulp.');
+		emitErr(stream, 'The sourcemap option must be true or false. See the readme for instructions on using Sass sourcemaps with gulp.');
 	}
 
 	// reassign options.sourcemap boolean to one of our two acceptable Sass arguments

--- a/index.js
+++ b/index.js
@@ -36,7 +36,7 @@ function gulpRubySass (source, options) {
 
 	options = assign(defaults, options);
 
-	// deprecation message for `container`.
+	// alert user that `container` is deprecated
 	if (options.container) {
 		gutil.log(gutil.colors.yellow(
 			'The container option has been deprecated. Simultanious tasks work automatically now!\n' +
@@ -44,7 +44,12 @@ function gulpRubySass (source, options) {
 	  ));
 	}
 
-	// sourcemap can only be true or false; warn those trying to pass a Sass string option
+	// error if user tries to watch their files with the Sass gem
+	if (options.watch || options.poll) {
+		throw new Error('`watch` and `poll` are not valid options for gulp-ruby-sass. Use `gulp.watch` to rebuild your files on change.');
+	}
+
+	// error if user tries to pass a Sass option to sourcemap
 	if (typeof options.sourcemap !== 'boolean') {
 		throw new Error('The sourcemap option must be true or false. See the readme for instructions on using Sass sourcemaps with gulp.');
 	}

--- a/readme.md
+++ b/readme.md
@@ -11,11 +11,6 @@ $ npm install --save-dev gulp-ruby-sass
 
 Requires [Sass >=3.4](http://sass-lang.com/install).
 
-## Important!
-
-- gulp-ruby-sass doesn't support incremental builds yet ([issue](https://github.com/sindresorhus/gulp-ruby-sass/issues/111)).
-- gulp-ruby-sass doesn't alter Sass's output in any way. Problems with Sass output should be reported to the [Sass issue tracker](https://github.com/sass/sass/issues).
-
 ## Usage
 
 ### sass(source, options)
@@ -221,6 +216,12 @@ Type: `Boolean`
 Default: `false`
 
 Silence warnings and status messages during compilation.
+
+## Issues
+
+This plugin wraps the Sass gem for the gulp build system. It does not alter Sass's output in any way. Any issues with Sass output should be reported to the [Sass issue tracker](https://github.com/sass/sass/issues).
+
+gulp-ruby-sass doesn't support Sass caching or incremental builds yet ([issue](https://github.com/sindresorhus/gulp-ruby-sass/issues/111)).
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -45,10 +45,6 @@ Type: `String`
 
 An object containing plugin and Sass options.
 
-#### Recompiling on changes
-
-Use [gulp-watch](https://github.com/gulpjs/gulp/blob/master/docs/API.md#gulpwatchglob--opts-tasks-or-gulpwatchglob--opts-cb) to automatically recompile your files on change.
-
 ### Plugin options
 
 #### verbose

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # gulp-ruby-sass [![Build Status](https://travis-ci.org/sindresorhus/gulp-ruby-sass.svg?branch=master)](https://travis-ci.org/sindresorhus/gulp-ruby-sass)
 
-Compiles Sass with the [Sass gem](http://sass-lang.com/install).  
+Compiles Sass with the [Sass gem](http://sass-lang.com/install) and pipes the results into a gulp stream.  
 To compile Sass with [libsass](http://libsass.org/), use [gulp-sass](https://github.com/dlmanning/gulp-sass)
 
 ## Install

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 # gulp-ruby-sass [![Build Status](https://travis-ci.org/sindresorhus/gulp-ruby-sass.svg?branch=master)](https://travis-ci.org/sindresorhus/gulp-ruby-sass)
 
-Compiles Sass with [the Sass gem](http://sass-lang.com/install).  
+Compiles Sass with the [Sass gem](http://sass-lang.com/install).  
 To compile Sass with [libsass](http://libsass.org/), use [gulp-sass](https://github.com/dlmanning/gulp-sass)
 
 
@@ -15,18 +15,15 @@ $ npm install --save-dev gulp-ruby-sass
 
 ## Important!
 
-- gulp-ruby-sass is a gulp source adapter. Use it instead of `gulp.src`.
-- Since it's a source adapter you need to catch errors on the stream itself instead of using a package like plumber. See the Usage section for examples.
-- gulp-ruby-sass doesn't support globs yet, only single files or directories. Just like Sass.
 - gulp-ruby-sass doesn't support incremental builds yet ([issue](https://github.com/sindresorhus/gulp-ruby-sass/issues/111)).
 - gulp-ruby-sass doesn't alter Sass's output in any way. Problems with Sass output should be reported to the [Sass issue tracker](https://github.com/sass/sass/issues).
 
 
 ## Usage
 
-Use gulp-ruby-sass instead of `gulp.src` to compile a file or directory.
+#### sass(source, options)
 
-Catch errors with an `on('error', cb)` listener. You can use the plugin's `logError` method to log pretty errors to your console. Erroring files will still be streamed unless you use Sass's `stopOnError` option.
+Use gulp-ruby-sass *instead of `gulp.src`* to compile Sass files.
 
 ```js
 var gulp = require('gulp');
@@ -38,6 +35,18 @@ gulp.task('sass', function () {
 		.pipe(gulp.dest('result'));
 });
 ```
+
+##### source
+
+Type: `string`
+
+A directory or file to compile. Note gulp-ruby-sass does not use globs. It only accepts the input values that Ruby Sass accepts.
+
+##### options
+
+Type: `string`
+
+An object containing plugin and Sass options.
 
 #### Recompiling on changes
 

--- a/readme.md
+++ b/readme.md
@@ -5,12 +5,11 @@ To compile Sass with [libsass](http://libsass.org/), use [gulp-sass](https://git
 
 ## Install
 
-You must have [Sass >=3.4](http://sass-lang.com/install).
-
 ```
 $ npm install --save-dev gulp-ruby-sass
 ```
 
+Requires [Sass >=3.4](http://sass-lang.com/install).
 
 ## Important!
 

--- a/readme.md
+++ b/readme.md
@@ -3,7 +3,6 @@
 Compiles Sass with the [Sass gem](http://sass-lang.com/install).  
 To compile Sass with [libsass](http://libsass.org/), use [gulp-sass](https://github.com/dlmanning/gulp-sass)
 
-
 ## Install
 
 You must have [Sass >=3.4](http://sass-lang.com/install).
@@ -17,7 +16,6 @@ $ npm install --save-dev gulp-ruby-sass
 
 - gulp-ruby-sass doesn't support incremental builds yet ([issue](https://github.com/sindresorhus/gulp-ruby-sass/issues/111)).
 - gulp-ruby-sass doesn't alter Sass's output in any way. Problems with Sass output should be reported to the [Sass issue tracker](https://github.com/sass/sass/issues).
-
 
 ## Usage
 
@@ -250,7 +248,6 @@ Type: `Boolean`
 Default: `false`
 
 Silence warnings and status messages during compilation.
-
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -18,7 +18,7 @@ Requires [Sass >=3.4](http://sass-lang.com/install).
 
 ## Usage
 
-#### sass(source, options)
+### sass(source, options)
 
 Use gulp-ruby-sass *instead of `gulp.src`* to compile Sass files.
 
@@ -33,13 +33,13 @@ gulp.task('sass', function () {
 });
 ```
 
-##### source
+#### source
 
 Type: `String`
 
 A directory or file to compile. Note gulp-ruby-sass does not use globs. It only accepts the input values that Ruby Sass accepts.
 
-##### options
+#### options
 
 Type: `String`
 
@@ -47,28 +47,19 @@ An object containing plugin and Sass options.
 
 ### Plugin options
 
-#### verbose
-
-Type: `Boolean`  
-Default: `false`
-
-Gives some extra information for debugging, including the actual spawned Sass command.
-
 #### bundleExec
 
 Type: `Boolean`  
 Default: `false`
 
-Run `sass` with [bundle exec](http://gembundler.com/man/bundle-exec.1.html).
+Run Sass with [bundle exec](http://gembundler.com/man/bundle-exec.1.html).
 
 #### sourcemap
 
 Type: `Boolean`  
 Default: `false`
 
-Requires Sass `>=3.4` and [`gulp-sourcemaps`](https://github.com/floridoo/gulp-sourcemaps).
-
-*Inline sourcemaps* are recommended, as they "just work".
+Initialize and pass Sass sourcemaps to [gulp-sourcemaps](https://github.com/floridoo/gulp-sourcemaps). Note this option replaces Sass's `sourcemap` option.
 
 ```js
 var gulp = require('gulp');
@@ -78,31 +69,24 @@ var sourcemaps = require('gulp-sourcemaps');
 gulp.task('sass', function () {
 	return sass('source', {sourcemap: true})
 		.on('error', sass.logError)
+
+		// For inline sourcemaps
 		.pipe(sourcemaps.write())
+
+		// For file sourcemaps
+		.pipe(sourcemaps.write('maps', {
+			includeContent: false,
+			sourceRoot: 'source'
+		}))
+
 		.pipe(gulp.dest('result'));
-});
-```
-
-*File sourcemaps* require you to serve the sourcemap location so the browser can read the files. See the [`gulp-sourcemaps` readme](https://github.com/floridoo/gulp-sourcemaps) for more info.
-
-```js
-gulp.task('sass', function() {
-	return sass('source', { sourcemap: true })
-	.on('error', sass.logError)
-
-	.pipe(sourcemaps.write('maps', {
-		includeContent: false,
-		sourceRoot: 'source'
-	}))
-
-	.pipe(gulp.dest('result'));
 });
 ```
 
 #### tempDir
 
 Type: `String`  
-Default: the OS temp directory as reported by [os-tempDir](https://github.com/sindresorhus/os-tmpdir)
+Default: the system temp directory as reported by [os-tempDir](https://github.com/sindresorhus/os-tmpdir)
 
 This plugin compiles Sass files to a temporary directory before pushing them through the stream. Use `tempDir` to choose an alternate directory if you aren't able to use the default OS temporary directory.
 
@@ -111,20 +95,14 @@ This plugin compiles Sass files to a temporary directory before pushing them thr
 Type: `Boolean`  
 Default: `false`
 
-If set to true the plugin will emit a gulp error when Sass compilation fails. This error can be used to exit the stream early. Note exiting early will break Sass's default behavior of writing a special CSS file that shows errors in the browser.
+Emit a gulp error when Sass compilation fails.
 
-```js
-gulp.task('sass', function () {
-	return sass('source', { emitCompileError: true })
+#### verbose
 
-	.on('error', function(err) {
-		sass.logError(err);
-		process.exit(1); // exit the stream immediately
-	})
+Type: `Boolean`  
+Default: `false`
 
-	.pipe(gulp.dest('result'));
-});
-```
+Log the spawned Sass or Bundler command. Useful for debugging.
 
 ### Sass options
 

--- a/readme.md
+++ b/readme.md
@@ -38,13 +38,13 @@ gulp.task('sass', function () {
 
 ##### source
 
-Type: `string`
+Type: `String`
 
 A directory or file to compile. Note gulp-ruby-sass does not use globs. It only accepts the input values that Ruby Sass accepts.
 
 ##### options
 
-Type: `string`
+Type: `String`
 
 An object containing plugin and Sass options.
 
@@ -56,21 +56,21 @@ Use [gulp-watch](https://github.com/gulpjs/gulp/blob/master/docs/API.md#gulpwatc
 
 #### verbose
 
-Type: `boolean`  
+Type: `Boolean`  
 Default: `false`
 
 Gives some extra information for debugging, including the actual spawned Sass command.
 
 #### bundleExec
 
-Type: `boolean`  
+Type: `Boolean`  
 Default: `false`
 
 Run `sass` with [bundle exec](http://gembundler.com/man/bundle-exec.1.html).
 
 #### sourcemap
 
-Type: `boolean`  
+Type: `Boolean`  
 Default: `false`
 
 Requires Sass `>=3.4` and [`gulp-sourcemaps`](https://github.com/floridoo/gulp-sourcemaps).
@@ -115,7 +115,7 @@ This plugin compiles Sass files to a temporary directory before pushing them thr
 
 #### emitCompileError
 
-Type: `boolean`  
+Type: `Boolean`  
 Default: `false`
 
 If set to true the plugin will emit a gulp error when Sass compilation fails. This error can be used to exit the stream early. Note exiting early will break Sass's default behavior of writing a special CSS file that shows errors in the browser.
@@ -141,112 +141,112 @@ The docs below list common options for convenience. Run `sass -h` for the comple
 
 #### loadPath
 
-Type: `string`, `array`  
+Type: `String` or `Array`  
 Default: `false`
 
 Import paths.
 
 #### require
 
-Type: `string`  
+Type: `String`  
 Default: `false`
 
 Require a Ruby library before running Sass.
 
 #### compass
 
-Type: `boolean`  
+Type: `Boolean`  
 Default: `false`
 
 Make Compass imports available and load project configuration.
 
 #### style
 
-Type: `string`  
+Type: `String`  
 Default: `nested`
 
 Output style. Can be nested (default), compact, compressed, or expanded.
 
 #### force
 
-Type: `boolean`  
+Type: `Boolean`  
 Default: `false`
 
 Recompile every Sass file, even if the CSS file is newer.
 
 #### stopOnError
 
-Type: `boolean`  
+Type: `Boolean`  
 Default: `false`
 
 If a file fails to compile, exit immediately.
 
 #### defaultEncoding
 
-Type: `string`  
+Type: `String`  
 Default: `false`
 
 Specify the default encoding for input files.
 
 #### unixNewlines
 
-Type: `boolean`  
+Type: `Boolean`  
 Default: `false`
 
 Use Unix-style newlines in written files on non-Unix systems. Always true on Unix.
 
 #### debugInfo
 
-Type: `boolean`  
+Type: `Boolean`  
 Default: `false`
 
 Emit output that can be used by the FireSass Firebug plugin.
 
 #### lineNumbers
 
-Type: `boolean`  
+Type: `Boolean`  
 Default: `false`
 
 Emit comments in the generated CSS indicating the corresponding source line.
 
 #### check
 
-Type: `boolean`  
+Type: `Boolean`  
 Default: `false`
 
 Just check syntax, don't evaluate.
 
 #### precision 
 
-Type: `number`  
+Type: `Number`  
 Default: `5`
 
 How many digits of precision to use when outputting decimal numbers.
 
 #### cacheLocation
 
-Type: `string`  
+Type: `String`  
 Default: `false`
 
 The path to save parsed Sass files. Defaults to .sass-cache.
 
 #### noCache
 
-Type: `boolean`  
+Type: `Boolean`  
 Default: `false`
 
 Don't cache parsed Sass files.
 
 #### trace
 
-Type: `boolean`  
+Type: `Boolean`  
 Default: `false`
 
 Show a full Ruby stack trace on error.
 
 #### quiet
 
-Type: `boolean`  
+Type: `Boolean`  
 Default: `false`
 
 Silence warnings and status messages during compilation.

--- a/readme.md
+++ b/readme.md
@@ -101,121 +101,22 @@ Log the spawned Sass or Bundler command. Useful for debugging.
 
 ### Sass options
 
-Any other options are passed directly to the Sass executable. The options are camelCase versions of Sass's dashed-case options.
+Any additional options are passed directly to the Sass executable. The options are camelCase versions of Sass's options parsed by [dargs](https://github.com/sindresorhus/dargs).
 
-The docs below list common options for convenience. Run `sass -h` for the complete list.
+Run `sass -h` for a complete list of Sass options.
 
-#### loadPath
-
-Type: `String` or `Array`  
-Default: `false`
-
-Import paths.
-
-#### require
-
-Type: `String`  
-Default: `false`
-
-Require a Ruby library before running Sass.
-
-#### compass
-
-Type: `Boolean`  
-Default: `false`
-
-Make Compass imports available and load project configuration.
-
-#### style
-
-Type: `String`  
-Default: `nested`
-
-Output style. Can be nested (default), compact, compressed, or expanded.
-
-#### force
-
-Type: `Boolean`  
-Default: `false`
-
-Recompile every Sass file, even if the CSS file is newer.
-
-#### stopOnError
-
-Type: `Boolean`  
-Default: `false`
-
-If a file fails to compile, exit immediately.
-
-#### defaultEncoding
-
-Type: `String`  
-Default: `false`
-
-Specify the default encoding for input files.
-
-#### unixNewlines
-
-Type: `Boolean`  
-Default: `false`
-
-Use Unix-style newlines in written files on non-Unix systems. Always true on Unix.
-
-#### debugInfo
-
-Type: `Boolean`  
-Default: `false`
-
-Emit output that can be used by the FireSass Firebug plugin.
-
-#### lineNumbers
-
-Type: `Boolean`  
-Default: `false`
-
-Emit comments in the generated CSS indicating the corresponding source line.
-
-#### check
-
-Type: `Boolean`  
-Default: `false`
-
-Just check syntax, don't evaluate.
-
-#### precision 
-
-Type: `Number`  
-Default: `5`
-
-How many digits of precision to use when outputting decimal numbers.
-
-#### cacheLocation
-
-Type: `String`  
-Default: `false`
-
-The path to save parsed Sass files. Defaults to .sass-cache.
-
-#### noCache
-
-Type: `Boolean`  
-Default: `false`
-
-Don't cache parsed Sass files.
-
-#### trace
-
-Type: `Boolean`  
-Default: `false`
-
-Show a full Ruby stack trace on error.
-
-#### quiet
-
-Type: `Boolean`  
-Default: `false`
-
-Silence warnings and status messages during compilation.
+```js
+gulp.task('sass', function () {
+	return sass('source/', {
+			precision: 6,
+			stopOnError: true,
+			cacheLocation: './',
+			loadPath: [ 'library', '../../shared-components' ]
+		})
+		.on('error', sass.logError)
+		.pipe(gulp.dest('result'));
+});
+```
 
 ## Issues
 

--- a/readme.md
+++ b/readme.md
@@ -22,9 +22,9 @@ var gulp = require('gulp');
 var sass = require('gulp-ruby-sass');
 
 gulp.task('sass', function () {
-	return sass('source/')
-		.on('error', sass.logError)
-		.pipe(gulp.dest('result'));
+  return sass('source/')
+    .on('error', sass.logError)
+    .pipe(gulp.dest('result'));
 });
 ```
 
@@ -62,19 +62,19 @@ var sass = require('gulp-ruby-sass');
 var sourcemaps = require('gulp-sourcemaps');
 
 gulp.task('sass', function () {
-	return sass('source', {sourcemap: true})
-		.on('error', sass.logError)
+  return sass('source', {sourcemap: true})
+    .on('error', sass.logError)
 
-		// For inline sourcemaps
-		.pipe(sourcemaps.write())
+    // For inline sourcemaps
+    .pipe(sourcemaps.write())
 
-		// For file sourcemaps
-		.pipe(sourcemaps.write('maps', {
-			includeContent: false,
-			sourceRoot: 'source'
-		}))
+    // For file sourcemaps
+    .pipe(sourcemaps.write('maps', {
+      includeContent: false,
+      sourceRoot: 'source'
+    }))
 
-		.pipe(gulp.dest('result'));
+    .pipe(gulp.dest('result'));
 });
 ```
 
@@ -107,14 +107,14 @@ Run `sass -h` for a complete list of Sass options.
 
 ```js
 gulp.task('sass', function () {
-	return sass('source/', {
-			precision: 6,
-			stopOnError: true,
-			cacheLocation: './',
-			loadPath: [ 'library', '../../shared-components' ]
-		})
-		.on('error', sass.logError)
-		.pipe(gulp.dest('result'));
+  return sass('source/', {
+      precision: 6,
+      stopOnError: true,
+      cacheLocation: './',
+      loadPath: [ 'library', '../../shared-components' ]
+    })
+    .on('error', sass.logError)
+    .pipe(gulp.dest('result'));
 });
 ```
 


### PR DESCRIPTION
The readme's length makes the plugin seem more complex than it actually is, and buries plugin information in a wall of text. This PR:

- Rearranges and rewords content for conciseness
- Moves some cautionary documentation into the plugin as errrors
- Standardizes documentation format with gulp documentation
- Removes Sass docs for [reasons outlined in the commit message](https://github.com/sindresorhus/gulp-ruby-sass/commit/a9a444c07f70e192f145b6dffb5911a5ea5883f1)