### PR TITLE
Remove slash module

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ var path = require('path');
 var Readable = require('stream').Readable;
 var glob = require('glob');
 var dargs = require('dargs');
-var slash = require('slash');
 var mkdirp = require('mkdirp');
 var rimraf = require('rimraf');
 var md5Hex = require('md5-hex');
@@ -59,7 +58,6 @@ function gulpRubySass (source, options) {
 
 	// create temporary directory path for the task using current working
 	// directory, source and options
-	// sass options need unix style slashes
 	var intermediateDir = uniqueIntermediateDirectory(options.tempDir, source);
 	var base;
 	var compileMapping;
@@ -75,11 +73,10 @@ function gulpRubySass (source, options) {
 	else {
 		base = path.join(cwd, path.dirname(source));
 
-		// sass options need unix style slashes
-		var dest = slash(path.join(
+		var dest = path.join(
 			intermediateDir,
 			gutil.replaceExtension(path.basename(source), '.css')
-		));
+		);
 
 		compileMapping = [ source, dest ];
 

--- a/package.json
+++ b/package.json
@@ -52,7 +52,6 @@
     "os-tmpdir": "^1.0.0",
     "path-exists": "^1.0.0",
     "rimraf": "^2.2.8",
-    "slash": "^1.0.0",
     "vinyl-fs": "^1.0.0",
     "win-spawn": "^2.0.0"
   },


### PR DESCRIPTION
It looks like the bug that we fixed on our end with slash is fixed in the Sass
gem. We require a version of Sass (3.4) that includes the fix, so out goes
slash.

See https://github.com/sindresorhus/gulp-ruby-sass/pull/251#discussion_r38267169
for more information.