### PR TITLE
Automatic Sass caching

### DIFF
--- a/index.js
+++ b/index.js
@@ -171,7 +171,7 @@ function gulpRubySass (sources, options) {
 					// if we are managing sourcemaps and a sourcemap exists
 					if (options.sourcemap === 'file' && pathExists.sync(file + '.map')) {
 						// remove sourcemap comment; gulp-sourcemaps will add it back in
-						data = new Buffer( convert.removeMapFileComments(data.toString()) );
+						data = new Buffer(convert.removeMapFileComments(data.toString()));
 						var sourcemapObject = JSON.parse(fs.readFileSync(file + '.map', 'utf8'));
 
 						// create relative paths for sources

--- a/index.js
+++ b/index.js
@@ -2,16 +2,17 @@
 var fs = require('fs');
 var path = require('path');
 var Readable = require('stream').Readable;
-var glob = require('glob');
-var dargs = require('dargs');
-var rimraf = require('rimraf');
-var spawn = require('win-spawn');
-var gutil = require('gulp-util');
+
 var assign = require('object-assign');
 var convert = require('convert-source-map');
+var dargs = require('dargs');
 var eachAsync = require('each-async');
+var glob = require('glob');
+var gutil = require('gulp-util');
 var osTmpdir = require('os-tmpdir');
 var pathExists = require('path-exists');
+var rimraf = require('rimraf');
+var spawn = require('win-spawn');
 
 var logger = require('./logger');
 var utils = require('./utils');

--- a/index.js
+++ b/index.js
@@ -21,16 +21,18 @@ var emitErr = utils.emitErr;
 var replaceLocation = utils.replaceLocation;
 var uniqueIntermediateDirectory = utils.uniqueIntermediateDirectory;
 
-function gulpRubySass (sources, options) {
-	options = assign({
-		tempDir: osTmpdir(),
-		verbose: false,
-		sourcemap: false,
-		emitCompileError: false
-	}, options);
+var defaults = {
+	tempDir: osTmpdir(),
+	verbose: false,
+	sourcemap: false,
+	emitCompileError: false
+};
 
+function gulpRubySass (sources, options) {
 	var stream = new Readable({objectMode: true});
 	stream._read = function () {}; 	// redundant but necessary
+
+	options = assign({}, defaults, options);
 
 	// alert user that `container` is deprecated
 	if (options.container) {
@@ -198,10 +200,21 @@ function gulpRubySass (sources, options) {
 	return stream;
 }
 
-gulpRubySass.logError = function logError(err) {
+gulpRubySass.logError = function (err) {
 	var message = new gutil.PluginError('gulp-ruby-sass', err);
 	process.stderr.write(message + '\n');
 	this.emit('end');
+};
+
+gulpRubySass.clearCache = function (tempDir, done) {
+	if (typeof tempDir === 'function') { done = tempDir; }
+	tempDir = tempDir || defaults.tempDir;
+	rimraf(path.join(tempDir, 'gulp-ruby-sass'), done);
+};
+
+gulpRubySass.clearCache.sync = function (tempDir) {
+	tempDir = tempDir || defaults.tempDir;
+	rimraf.sync(path.join(tempDir, 'gulp-ruby-sass'));
 };
 
 module.exports = gulpRubySass;

--- a/index.js
+++ b/index.js
@@ -206,13 +206,7 @@ gulpRubySass.logError = function (err) {
 	this.emit('end');
 };
 
-gulpRubySass.clearCache = function (tempDir, done) {
-	if (typeof tempDir === 'function') { done = tempDir; }
-	tempDir = tempDir || defaults.tempDir;
-	rimraf(path.join(tempDir, 'gulp-ruby-sass'), done);
-};
-
-gulpRubySass.clearCache.sync = function (tempDir) {
+gulpRubySass.clearCache = function (tempDir) {
 	tempDir = tempDir || defaults.tempDir;
 	rimraf.sync(path.join(tempDir, 'gulp-ruby-sass'));
 };

--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var gutil = require('gulp-util');
 var osTmpdir = require('os-tmpdir');
 var pathExists = require('path-exists');
 var rimraf = require('rimraf');
-var spawn = require('win-spawn');
+var spawn = require('cross-spawn-async');
 
 var logger = require('./logger');
 var utils = require('./utils');

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ var utils = require('./utils');
 
 var emitErr = utils.emitErr;
 var replaceLocation = utils.replaceLocation;
-var uniqueIntermediateDirectory = utils.uniqueIntermediateDirectory;
+var createIntermediateDir = utils.createIntermediateDir;
 
 var defaults = {
 	tempDir: osTmpdir(),
@@ -66,7 +66,7 @@ function gulpRubySass (sources, options) {
 		bases.push(options.base || utils.calculateBase(source));
 	});
 
-	var intermediateDir = uniqueIntermediateDirectory(sources, matches, options);
+	var intermediateDir = createIntermediateDir(sources, matches, options);
 	var compileMappings = [];
 	var baseMappings = {};
 

--- a/logger.js
+++ b/logger.js
@@ -4,11 +4,11 @@ var emitErr = require('./utils').emitErr;
 
 // Remove intermediate directory for more Sass-like logging
 function prettifyDirectoryLogging (msg, intermediateDir) {
-	return msg.replace(new RegExp((intermediateDir) + '/?', 'g'), './');
+	return msg.replace(new RegExp(intermediateDir + '/?', 'g'), './');
 }
 
 module.exports = {
-	verbose: function  (command, args) {
+	verbose: function (command, args) {
 		gutil.log('Running command ' + command + ' ' + args.join(' '));
 	},
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   ],
   "dependencies": {
     "convert-source-map": "^1.0.0",
+    "cross-spawn-async": "^2.0.0",
     "dargs": "^2.0.3",
     "each-async": "^1.0.0",
     "glob": "^5.0.5",
@@ -52,8 +53,7 @@
     "os-tmpdir": "^1.0.0",
     "path-exists": "^1.0.0",
     "rimraf": "^2.2.8",
-    "vinyl-fs": "^1.0.0",
-    "win-spawn": "^2.0.0"
+    "vinyl-fs": "^1.0.0"
   },
   "devDependencies": {
     "gulp": "^3.8.11",

--- a/readme.md
+++ b/readme.md
@@ -126,6 +126,10 @@ gulp.task('sass', function () {
 
 A convenience function for pretty error logging.
 
+### sass.clearCache([tempDir])
+
+In rare cases you may need to clear gulp-ruby-sass's cache. This sync function deletes all files used for Sass caching. If you've set a custom temporary directory in your task you must pass it to `clearCache`.
+
 ## Issues
 
 This plugin wraps the Sass gem for the gulp build system. It does not alter Sass's output in any way. Any issues with Sass output should be reported to the [Sass issue tracker](https://github.com/sass/sass/issues).

--- a/readme.md
+++ b/readme.md
@@ -130,8 +130,6 @@ A convenience function for pretty error logging.
 
 This plugin wraps the Sass gem for the gulp build system. It does not alter Sass's output in any way. Any issues with Sass output should be reported to the [Sass issue tracker](https://github.com/sass/sass/issues).
 
-gulp-ruby-sass doesn't support Sass caching or incremental builds... yet ([issue](https://github.com/sindresorhus/gulp-ruby-sass/issues/111)).
-
 ## License
 
 MIT © [Sindre Sorhus](http://sindresorhus.com)

--- a/test/special/computational.scss
+++ b/test/special/computational.scss
@@ -1,0 +1,5 @@
+@for $i from 1 through 4000 {
+  .class-#{$i} {
+    width: 60px * $i;
+  }
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,9 @@
 'use strict';
 var fs = require('fs');
 var path = require('path');
-var rimraf = require('rimraf');
 var assert = require('assert');
 var assign = require('object-assign');
+var rimraf = require('rimraf');
 var vinylFile = require('vinyl-file');
 
 var sass = require('../');

--- a/test/test.js
+++ b/test/test.js
@@ -376,7 +376,7 @@ describe('options', function () {
 
 describe('caching', function () {
 	it('compiles an unchanged file faster the second time', function (done) {
-		sass.clearCache.sync();
+		sass.clearCache();
 
 		var startOne = new Date();
 

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,4 @@
 'use strict';
-var fs = require('fs');
 var path = require('path');
 var assert = require('assert');
 var assign = require('object-assign');
@@ -238,8 +237,8 @@ describe('sourcemap', function () {
 
 	describe('compiling files from glob source', function () {
 		var expected = [
-			[ '_partial.scss' ],
-			[ '_partial.scss', 'file.scss', 'directory/_nested-partial.scss' ]
+			['_partial.scss'],
+			['_partial.scss', 'file.scss', 'directory/_nested-partial.scss']
 		];
 
 		before(function (done) {
@@ -364,7 +363,7 @@ describe('options', function () {
 			sass(source, options)
 
 			.on('data', function () {
-				assert( pathExists.sync(tempDir) );
+				assert(pathExists.sync(tempDir));
 			})
 
 			// clean up if tests are run locally
@@ -385,7 +384,7 @@ describe('caching', function () {
 		.on('data', function () {})
 		.on('end', function () {
 			var endOne = new Date();
-    	var runtimeOne = endOne - startOne;
+			var runtimeOne = endOne - startOne;
 
 			sass('special/computational.scss', defaultOptions)
 			.on('data', function () {})

--- a/test/test.js
+++ b/test/test.js
@@ -14,7 +14,7 @@ var defaultOptions = {
 };
 
 // load the expected result file from the compiled results directory
-var expectedFile = function (relativePath, base) {
+var loadExpectedFile = function (relativePath, base) {
 	base = base || 'result';
 	var file = path.join(base, relativePath);
 	return vinylFile.readSync(file, { base: base });
@@ -27,7 +27,7 @@ var sortByRelative = function (a, b) {
 describe('single file', function () {
 	this.timeout(20000);
 	var files = [];
-	var expected = expectedFile('file.css');
+	var expected = loadExpectedFile('file.css');
 
 	before(function (done) {
 		sass('source/file.scss', defaultOptions)
@@ -59,11 +59,11 @@ describe('multiple files', function () {
 	this.timeout(20000);
 	var files = [];
 	var expected = [
-		expectedFile('directory with spaces/file with spaces.css'),
-		expectedFile('directory/file.css'),
-		expectedFile('error.css'),
-		expectedFile('file.css'),
-		expectedFile('warnings.css')
+		loadExpectedFile('directory with spaces/file with spaces.css'),
+		loadExpectedFile('directory/file.css'),
+		loadExpectedFile('error.css'),
+		loadExpectedFile('file.css'),
+		loadExpectedFile('warnings.css')
 	];
 
 	before(function (done) {
@@ -115,8 +115,8 @@ describe('array sources', function () {
 	this.timeout(20000);
 	var files = [];
 	var expected = [
-		expectedFile('file with spaces.css', 'result/directory with spaces'),
-		expectedFile('file.css')
+		loadExpectedFile('file with spaces.css', 'result/directory with spaces'),
+		loadExpectedFile('file.css')
 	];
 
 	before(function (done) {
@@ -310,8 +310,8 @@ describe('options', function () {
 		this.timeout(20000);
 		var files = [];
 		var expected = [
-			expectedFile('directory/file.css'),
-			expectedFile('file.css')
+			loadExpectedFile('directory/file.css'),
+			loadExpectedFile('file.css')
 		];
 		var options = assign({}, defaultOptions, { base: 'source' });
 

--- a/test/test.js
+++ b/test/test.js
@@ -30,7 +30,7 @@ describe('single file', function () {
 	var files = [];
 	var expected = expectedFile('file.css');
 
-	before(function(done) {
+	before(function (done) {
 		sass('source/file.scss', defaultOptions)
 		.on('data', function (data) {
 			files.push(data);
@@ -67,12 +67,12 @@ describe('multiple files', function () {
 		expectedFile('warnings.css')
 	];
 
-	before(function(done) {
+	before(function (done) {
 		sass('source/**/*.scss', defaultOptions)
 		.on('data', function (data) {
 			files.push(data);
 		})
-		.on('end', function() {
+		.on('end', function () {
 			files.sort(sortByRelative);
 			done();
 		});
@@ -120,7 +120,7 @@ describe('array sources', function () {
 		expectedFile('file.css')
 	];
 
-	before(function(done) {
+	before(function (done) {
 		sass([
 			'source/file.scss',
 			'source/directory with spaces/file with spaces.scss'
@@ -128,7 +128,7 @@ describe('array sources', function () {
 		.on('data', function (data) {
 			files.push(data);
 		})
-		.on('end', function() {
+		.on('end', function () {
 			files.sort(sortByRelative);
 			done();
 		});
@@ -162,12 +162,12 @@ describe('concurrently run tasks', function () {
 	var bFiles = [];
 	var cFiles = [];
 	var counter = 0;
-	var isDone = function(done) {
+	var isDone = function (done) {
 		counter++;
 		if (counter === 3) { done(); }
 	};
 
-	before(function(done) {
+	before(function (done) {
 		sass('source/file.scss', defaultOptions)
 		.on('data', function (data) {
 			aFiles.push(data);
@@ -205,7 +205,7 @@ describe('sourcemap', function () {
 	var files = [];
 	var options = assign({}, defaultOptions, { sourcemap: true });
 
-	before(function(done) {
+	before(function (done) {
 		sass('source/file.scss', options)
 		.on('data', function (data) {
 			files.push(data);
@@ -242,14 +242,14 @@ describe('sourcemap', function () {
 			[ '_partial.scss', 'file.scss', 'directory/_nested-partial.scss' ]
 		];
 
-		before(function(done) {
+		before(function (done) {
 			files = [];
 
 			sass('source/**/file.scss', options)
 			.on('data', function (data) {
 				files.push(data);
 			})
-			.on('end', function() {
+			.on('end', function () {
 				files.sort(sortByRelative);
 				done();
 			});
@@ -265,7 +265,7 @@ describe('sourcemap', function () {
 	describe('compiling files and directories with spaces', function () {
 		var expected = ['file with spaces.scss'];
 
-		before(function(done) {
+		before(function (done) {
 			files = [];
 
 			sass('source/directory with spaces/file with spaces.scss', options)
@@ -287,7 +287,7 @@ describe('options', function () {
 	describe('emitCompileError', function () {
 		var error;
 
-		before(function(done) {
+		before(function (done) {
 			var options = assign({}, defaultOptions, { emitCompileError: true });
 
 			sass('source/error.scss', options)
@@ -316,12 +316,12 @@ describe('options', function () {
 		];
 		var options = assign({}, defaultOptions, { base: 'source' });
 
-		before(function(done) {
+		before(function (done) {
 			sass(['source/file.scss', 'source/directory/file.scss'], options)
 			.on('data', function (data) {
 				files.push(data);
 			})
-			.on('end', function() {
+			.on('end', function () {
 				files.sort(sortByRelative);
 				done();
 			});

--- a/test/test.js
+++ b/test/test.js
@@ -363,15 +363,40 @@ describe('options', function () {
 
 			sass(source, options)
 
-			.on('data', function (data) {
-				console.log('heloo');
-
+			.on('data', function () {
 				assert( pathExists.sync(tempDir) );
 			})
 
 			// clean up if tests are run locally
 			.on('end', function () {
 				rimraf(tempDir, done);
+			});
+		});
+	});
+});
+
+describe('caching', function () {
+	it('compiles an unchanged file faster the second time', function (done) {
+		sass.clearCache.sync();
+
+		var startOne = new Date();
+
+		sass('special/computational.scss', defaultOptions)
+		.on('data', function () {})
+		.on('end', function () {
+			var endOne = new Date();
+    	var runtimeOne = endOne - startOne;
+
+			sass('special/computational.scss', defaultOptions)
+			.on('data', function () {})
+			.on('end', function () {
+				var runtimeTwo = new Date() - endOne;
+
+				assert(
+					runtimeOne > runtimeTwo + 50, // pad time to avoid potential intermittents
+					'Compilation times were not decreased significantly. Caching may be broken.'
+				);
+				done();
 			});
 		});
 	});

--- a/test/test.js
+++ b/test/test.js
@@ -3,11 +3,11 @@ var fs = require('fs');
 var path = require('path');
 var assert = require('assert');
 var assign = require('object-assign');
+var pathExists = require('path-exists');
 var rimraf = require('rimraf');
 var vinylFile = require('vinyl-file');
 
 var sass = require('../');
-var uniqueIntermediateDirectory = require('../utils').uniqueIntermediateDirectory;
 
 var defaultOptions = {
 	quiet: true,
@@ -355,22 +355,21 @@ describe('options', function () {
 			var tempDir = './custom-temp-dir';
 			var options = assign({}, defaultOptions, { tempDir: tempDir });
 
-			sass(source, options)
-			.on('data', function (data) {
-				// the plugin transforms the sources argument into an array before
-				// passing to uniqueIntermediateDirectory
-				var sources = [source];
-				var expectedFileLocation = path.join(
-					uniqueIntermediateDirectory(tempDir, sources),
-					data.relative
-				);
+			assert.equal(
+				pathExists.sync(tempDir),
+				false,
+				'The temporary directory already exists, and would create false positives.'
+			);
 
-				assert.equal(
-					data.contents.toString(),
-					fs.readFileSync(expectedFileLocation, {encoding: 'utf8'}),
-					'File does not exist in the custom temporary directory.'
-				);
+			sass(source, options)
+
+			.on('data', function (data) {
+				console.log('heloo');
+
+				assert( pathExists.sync(tempDir) );
 			})
+
+			// clean up if tests are run locally
 			.on('end', function () {
 				rimraf(tempDir, done);
 			});

--- a/utils.js
+++ b/utils.js
@@ -11,12 +11,20 @@ utils.emitErr = function (stream, err) {
 	stream.emit('error', new gutil.PluginError('gulp-ruby-sass', err));
 };
 
-// create temporary directory path for a specific task using cwd and sources
-utils.uniqueIntermediateDirectory = function (tempDir, sources) {
+// Create unique temporary directory path per task using cwd, options, sources,
+// and all matched files. Options must be checked in case the user is switching
+// tempDir or sourcemaps on or off. Sourcemap may be a bug; See
+// https://github.com/sass/sass/issues/1830
+utils.uniqueIntermediateDirectory = function (sources, matches, options) {
 	return path.join(
-		tempDir,
+		options.tempDir,
 		'gulp-ruby-sass',
-		'cwd-' + md5Hex(process.cwd()) + '-sources-' + md5Hex(JSON.stringify(sources))
+		md5Hex(
+			process.cwd() +
+			JSON.stringify(sources) +
+			JSON.stringify(matches) +
+			options.sourcemap
+		)
 	);
 };
 

--- a/utils.js
+++ b/utils.js
@@ -1,9 +1,9 @@
 'use strict';
 var path = require('path');
 var glob = require('glob');
-var md5Hex = require('md5-hex');
-var gutil = require('gulp-util');
 var glob2base = require('glob2base');
+var gutil = require('gulp-util');
+var md5Hex = require('md5-hex');
 
 var utils = {};
 

--- a/utils.js
+++ b/utils.js
@@ -15,7 +15,7 @@ utils.emitErr = function (stream, err) {
 // and all matched files. Options must be checked in case the user is switching
 // tempDir or sourcemaps on or off. Sourcemap may be a bug; See
 // https://github.com/sass/sass/issues/1830
-utils.uniqueIntermediateDirectory = function (sources, matches, options) {
+utils.createIntermediateDir = function (sources, matches, options) {
 	return path.join(
 		options.tempDir,
 		'gulp-ruby-sass',


### PR DESCRIPTION
No more removing the intermediate directory! I fix the issue with renaming or removing files by creating an intermediate directory based on *all matched files*. Also fixing a Sass issue by including the sourcemap option in the intermediate directory: https://github.com/sass/sass/issues/1830.

Anyways, caching works as long as you're compiling the same files with the same options. 90% use case.