### PR TITLE
Use non-deprecated cross-spawn package

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,7 @@ var gutil = require('gulp-util');
 var osTmpdir = require('os-tmpdir');
 var pathExists = require('path-exists');
 var rimraf = require('rimraf');
-var spawn = require('cross-spawn-async');
+var spawn = require('cross-spawn');
 var logger = require('./lib/logger');
 var utils = require('./lib/utils');
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "dependencies": {
     "convert-source-map": "^1.0.0",
-    "cross-spawn-async": "^2.0.0",
+    "cross-spawn": "^4.0.2",
     "dargs": "^2.0.3",
     "each-async": "^1.0.0",
     "escape-string-regexp": "^1.0.3",


### PR DESCRIPTION
`cross-spawn-async` is [deprecated](https://github.com/IndigoUnited/node-cross-spawn-async) and spits out warnings during install. Use `cross-spawn` ([IndigoUnited/node-cross-spawn](https://github.com/IndigoUnited/node-cross-spawn)) instead.
