### PR TITLE
Enabled watch option

### DIFF
--- a/index.js
+++ b/index.js
@@ -179,7 +179,7 @@ function gulpRubySass(sources, options) {
 
 	return stream;
 
-	function pushVinylFile(file) {
+	function pushVinylFile(file, callback) {
 		// Rewrite file paths so gulp thinks the file came from cwd, not the
 		// intermediate directory
 		const relative = path.relative(intermediateDir, file.replace('.map', ''));

--- a/index.js
+++ b/index.js
@@ -46,9 +46,9 @@ function gulpRubySass(sources, options) {
 		fancyLog(chalk.yellow('The container option has been deprecated. Simultaneous tasks work automatically now!'));
 	}
 
-	// Error if user tries to watch their files with the Sass gem
-	if (options.watch || options.poll) {
-		emitErr(stream, '`watch` and `poll` are not valid options for gulp-ruby-sass. Use `gulp.watch` to rebuild your files on change.');
+	// Error if user tries to use poll option
+	if (options.poll) {
+		emitErr(stream, '`poll` is not a valid option for gulp-ruby-sass.');
 	}
 
 	// Error if user tries to pass a Sass option to sourcemap
@@ -57,7 +57,9 @@ function gulpRubySass(sources, options) {
 	}
 
 	options.sourcemap = options.sourcemap === true ? 'file' : 'none';
-	options.update = true;
+	if (!options.watch) {
+		options.update = true;
+    }
 
 	// Simplified handling of array sources, like gulp.src
 	if (!Array.isArray(sources)) {
@@ -107,7 +109,6 @@ function gulpRubySass(sources, options) {
 
 	const args = dargs(options, [
 		'bundleExec',
-		'watch',
 		'poll',
 		'tempDir',
 		'verbose',

--- a/index.js
+++ b/index.js
@@ -181,7 +181,7 @@ function gulpRubySass(sources, options) {
 	function pushVinylFile(file, intermediateDir) {
 		// Rewrite file paths so gulp thinks the file came from cwd, not the
 		// intermediate directory
-		const relative = path.relative(intermediateDir, file);
+		const relative = path.relative(intermediateDir, file.replace('.map', ''));
 		const base = baseMappings[relative];
 
 		fs.readFile(file, (err, data) => {

--- a/index.js
+++ b/index.js
@@ -59,7 +59,7 @@ function gulpRubySass(sources, options) {
 	options.sourcemap = options.sourcemap === true ? 'file' : 'none';
 	if (!options.watch) {
 		options.update = true;
-    }
+	}
 
 	// Simplified handling of array sources, like gulp.src
 	if (!Array.isArray(sources)) {

--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ function gulpRubySass(sources, options) {
 		logger.stdout(stream, intermediateDir, data);
 		let filePath = data.match(/write\s+(\/.*)/);
 		if (filePath && filePath.length && filePath.length > 1) {
-			pushVinylFile(filePath[1], intermediateDir);
+			pushVinylFile(filePath[1]);
 		}
 	});
 
@@ -168,8 +168,9 @@ function gulpRubySass(sources, options) {
 					return;
 				}
 
-				pushVinylFile(file, intermediateDir);
-				next();
+				pushVinylFile(file, function() {
+					next();
+				})
 			}, () => {
 				stream.push(null);
 			});
@@ -178,7 +179,7 @@ function gulpRubySass(sources, options) {
 
 	return stream;
 
-	function pushVinylFile(file, intermediateDir) {
+	function pushVinylFile(file) {
 		// Rewrite file paths so gulp thinks the file came from cwd, not the
 		// intermediate directory
 		const relative = path.relative(intermediateDir, file.replace('.map', ''));
@@ -187,7 +188,7 @@ function gulpRubySass(sources, options) {
 		fs.readFile(file, (err, data) => {
 			if (err) {
 				emitErr(stream, err);
-				next();
+				callback && callback();
 				return;
 			}
 
@@ -216,10 +217,9 @@ function gulpRubySass(sources, options) {
 			}
 
 			vinylFile.contents = data;
-
 			stream.push(vinylFile);
+			callback && callback();
 		});
-
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -223,7 +223,7 @@ function gulpRubySass(sources, options) {
 	}
 }
 
-gulpRubySass.logError = err => {
+gulpRubySass.logError = function(err) {
 	const message = new PluginError('gulp-ruby-sass', err);
 	process.stderr.write(`${message}\n`);
 	this.emit('end');


### PR DESCRIPTION
I think it's time to enable watch option. Problem with gulp.watch is that if you don't want to rebuild your whole directory on every change you have to build individual files returned from watch callback, but this way the changes to partials will be ignored by watch.

There are solutions like https://www.npmjs.com/package/gulp-watch-sass, but they don't work with gulp-ruby-sass.

The sass watch option works perfectly and updates all files where partial is used. I believe it should be up to users whether to use it or not.